### PR TITLE
Completed Flask Get Request for trained models. Cleaned some unused import statements.

### DIFF
--- a/server/kepler_model_trainer.py
+++ b/server/kepler_model_trainer.py
@@ -3,7 +3,6 @@ from keras.models import Sequential, load_model
 from keras import layers
 import numpy as np
 import os
-import pandas as pd
 
 # Dict to map model type with filepath
 model_type_to_filepath = {"CoreEnergyConsumption": "models/core_model", "DramEnergyConsumption": "models/dram_model"}

--- a/server/server.py
+++ b/server/server.py
@@ -1,6 +1,9 @@
-from flask import Flask, redirect, url_for, request, json, current_app, send_from_directory
+from ast import mod
+from flask import Flask, redirect, url_for, request, json, current_app, send_from_directory, make_response
 import os
 app = Flask(__name__)
+import shutil
+
 
 @app.route('/model',methods = ['POST', 'GET'])
 def model():
@@ -9,20 +12,30 @@ def model():
       app.logger.warn("BODY: %s" % ret)
       return ret
 
+
 @app.route('/data',methods = ['POST', 'GET'])
 def data():
    if request.method == 'POST':
       app.logger.warn("BODY: %s" % request.get_data())
       return 'success'
 
-#Required to send models. There are no models created yet.
+
+# Returns a trained model given the model type/name. Currently, the route will return an archived file of keras's SavedModel.
+# The extracted archived SavedModel can be directly fitted. To download the SavedModel as attachment, include as_attachment=True in the 
+# send_from_directory flask function. Other lightweight options include sending the model as a HDF5 format, sending the model
+# structure as a JSON and the model's weights as an HDF5 file. 
 @app.route('/models/<model_type>', methods=['GET'])
-def get_model(model_type='core'):
-    models_directory = os.path.join(current_app.root_path, '/models/')
-    if model_type == 'dram':
-        return send_from_directory(directory=models_directory, filename='dram_model')
-    elif model_type == 'core':
-        return send_from_directory(directory=models_directory, filename='core_model')
+@app.route('/models/')
+def get_model(model_type='core_model'):
+    models_directory = os.path.join(current_app.root_path, 'models/')
+    if model_type == 'dram_model' and os.path.exists(os.path.join(models_directory, 'dram_model')): # must check whether the model was created or not
+        shutil.make_archive(os.path.join(models_directory, 'dram_model'), 'zip', os.path.join(models_directory, 'dram_model')) # this function should overrite an existing zipped model
+        return send_from_directory(models_directory, 'dram_model.zip')
+    elif model_type == 'core_model' and os.path.exists(os.path.join(models_directory, 'core_model')): # must check whether the model was created or not
+        shutil.make_archive(os.path.join(models_directory, 'core_model'), 'zip', os.path.join(models_directory, 'core_model')) # this function should overrite an existing zipped model
+        return send_from_directory(models_directory, 'core_model.zip') 
+    else:
+        return make_response("Model '" + model_type + "' does not exist at the moment", 400)
 
 
 def makeCoeff():
@@ -40,5 +53,7 @@ def makeCoeff():
     )
     return response
 
+
 if __name__ == '__main__':
    app.run(host="0.0.0.0", debug=True, port=8100)
+   


### PR DESCRIPTION
Implemented and tested Flask Get Request feature that returns trained models given the model name/type. Currently, the most recent models are returned as archive zipped files of keras SavedModel format (which are obtained after training). If the feature cannot find a trained model of the desired type (ex. dram and core energy consumption models) or the model has not been trained/created yet, it will return a response with status 400. Once unzipped, the model folder can be used directly for fitting. Note that there are other ways of returning trained models to Kepler that are more lightweight and less comprehensive (ex. JSON, HDF5 files) which can be used instead if necessary. 