### PR TITLE
Refractored and improved code

### DIFF
--- a/server/kepler_model_trainer.py
+++ b/server/kepler_model_trainer.py
@@ -3,9 +3,10 @@ from keras.models import Sequential, load_model
 from keras import layers
 import numpy as np
 import os
+import shutil
 
 # Dict to map model type with filepath
-model_type_to_filepath = {"CoreEnergyConsumption": "models/core_model", "DramEnergyConsumption": "models/dram_model"}
+model_type_to_filepath = {"core_model": "models/core_model", "dram_model": "models/dram_model"}
 
 # Generates a new regression model with normalized features
 # precondition: data has already been cleaned (no missing data)
@@ -22,12 +23,26 @@ def generate_regression_model(train_features) -> Sequential:
     new_linear_model.compile(optimizer=tf.optimizers.Adam(learning_rate=0.1), loss='mean_absolute_error')
     return new_linear_model
 
+# Helper function to verify model_type is valid, check whether the model has been created or not,
+# and create a filepath to the model.
+# Returns type (str, Bool) where str is the filepath to the model_type or None if the model_type
+# is invalid, and Bool is True if the model of the desired type was already created and False if the model
+# of the desired type has not been created. If str is None, then Bool is False.
+def return_model_filepath(model_type):
+    if model_type in model_type_to_filepath:
+        filepath = os.path.join(os.path.dirname(__file__), model_type_to_filepath[model_type])
+        return filepath, os.path.exists(filepath)
+        #if os.path.exists(filepath):
+        #    return filepath, True
+        #return filepath, False
+    return None, False
+        
 
 def train_model_given_data_and_type(train_features, train_labels, test_features, test_labels, model_type):
     # TODO: Include Demo using excel data - returns evaluation details and coefficients
-    if model_type in model_type_to_filepath:
-        filepath = os.path.join(os.path.dirname(__file__), model_type_to_filepath[model_type])
-        if os.path.exists(filepath):
+    filepath, model_exists = return_model_filepath(model_type)
+    if filepath is not None:
+        if model_exists:
             returned_model = load_model(filepath)
             returned_model.fit(train_features, train_labels, epochs=10, validation_split=0.1)
             results = returned_model.evaluate(test_features, test_labels, verbose=1)
@@ -54,7 +69,18 @@ def train_model_given_data_and_type(train_features, train_labels, test_features,
     #    new_model = generate_regression_model(train_features)
         # new_model.fit(train_features, train_labels, epochs=100)
     #    save_model(returned_model, 'models/core_model.h5')
+
+def archive_saved_model(model_type):
+    filepath, model_exists = return_model_filepath(model_type)
+    if filepath is None:
+        raise ValueError("Provided Model Type is invalid and/or not included")
+    if not model_exists:
+        raise FileNotFoundError("The desired trained model is valid, but the model has not been created/saved yet")
     
+    shutil.make_archive(filepath, 'zip', filepath)
+    # return archived zipped filepath directory
+    return os.path.join(os.path.dirname(__file__), 'models/'), model_type + '.zip'
+
 
 #def train_dram_model(train_features, train_labels, test_features, test_labels):
     # TODO: Include Demo using dataset in the form of an excel file - returns evaluation details and coefficients    
@@ -71,3 +97,4 @@ def train_model_given_data_and_type(train_features, train_labels, test_features,
         # new_model.fit(train_features, train_labels, epochs=100)
         # new_model.evaluate(test_features, test_labels, verbose=0)
     #    save_model(returned_model, 'models/dram_model.h5')
+

--- a/server/server.py
+++ b/server/server.py
@@ -1,11 +1,12 @@
 from ast import mod
+from multiprocessing.sharedctypes import Value
 from flask import Flask, redirect, url_for, request, json, current_app, send_from_directory, make_response
 import os
-import shutil
+from kepler_model_trainer import archive_saved_model
 
 app = Flask(__name__)
 
-
+# Obsolete Test Legacy Code: June 13, 2022
 @app.route('/model',methods = ['POST', 'GET'])
 def model():
    if request.method == 'GET':
@@ -13,13 +14,15 @@ def model():
       app.logger.warn("BODY: %s" % ret)
       return ret
 
-
+# Obsolete Test Legacy Code: June 13, 2022
 @app.route('/data',methods = ['POST', 'GET'])
 def data():
    if request.method == 'POST':
       app.logger.warn("BODY: %s" % request.get_data())
       return 'success'
 
+
+# Acceptable model_type values: core_model, dram_model
 
 # Returns a trained model given the model type/name. Currently, the route will return an archived file of keras's SavedModel.
 # The extracted archived SavedModel can be directly fitted. To download the SavedModel as attachment, include as_attachment=True in the 
@@ -28,15 +31,24 @@ def data():
 @app.route('/models/<model_type>', methods=['GET'])
 @app.route('/models/')
 def get_model(model_type='core_model'):
-    models_directory = os.path.join(current_app.root_path, 'models/')
-    if model_type == 'dram_model' and os.path.exists(os.path.join(models_directory, 'dram_model')): # must check whether the model was created or not
-        shutil.make_archive(os.path.join(models_directory, 'dram_model'), 'zip', os.path.join(models_directory, 'dram_model')) # this function should overrite an existing zipped model
-        return send_from_directory(models_directory, 'dram_model.zip')
-    if model_type == 'core_model' and os.path.exists(os.path.join(models_directory, 'core_model')): # must check whether the model was created or not
-        shutil.make_archive(os.path.join(models_directory, 'core_model'), 'zip', os.path.join(models_directory, 'core_model')) # this function should overrite an existing zipped model
-        return send_from_directory(models_directory, 'core_model.zip') 
-    
-    return make_response("Model '" + model_type + "' does not exist at the moment", 400)
+    #models_directory = os.path.join(current_app.root_path, 'models/')
+    try:
+        filepath, name_of_file = archive_saved_model(model_type)
+        print(name_of_file)
+        return send_from_directory(filepath, name_of_file, as_attachment=True)
+    except ValueError:
+        return make_response("Model '" + model_type + "' is not valid", 400)
+    except FileNotFoundError:
+        return make_response("Model '" + model_type + "' does not exist at the moment", 400)
+
+    #models_directory = os.path.join(current_app.root, 'models/')
+    #if model_type == 'dram_model' and os.path.exists(os.path.join(models_directory, 'dram_model')): # must check whether the model was created or not
+         #shutil.make_archive(os.path.join(models_directory, 'dram_model'), 'zip', os.path.join(models_directory, 'dram_model')) # this function should overrite an existing zipped model
+    #    return send_from_directory(models_directory, 'dram_model.zip')
+    #if model_type == 'core_model' and os.path.exists(os.path.join(models_directory, 'core_model')): # must check whether the model was created or not
+    #    shutil.make_archive(os.path.join(models_directory, 'core_model'), 'zip', os.path.join(models_directory, 'core_model')) # this function should overrite an existing zipped model
+    #    return send_from_directory(models_directory, 'core_model.zip')
+    #return make_response("Model '" + model_type + "' does not exist at the moment", 400)
 
 
 def makeCoeff():

--- a/tests/kepler_regression_model_tests.py
+++ b/tests/kepler_regression_model_tests.py
@@ -28,7 +28,7 @@ def test_core_regression_model():
     #print(core_train_features)
 
     # Train core with the linear regression model    
-    train_model_given_data_and_type(core_train_features, core_target_train, core_test_features, core_target_test, "CoreEnergyConsumption")
+    train_model_given_data_and_type(core_train_features, core_target_train, core_test_features, core_target_test, "core_model")
 
 
 def test_dram_regression_model():
@@ -52,7 +52,7 @@ def test_dram_regression_model():
     dram_target_test = dram_test_features.pop('curr_energy_in_dram')
     #print(dram_train_features.loc[0])
     # Train dram with the linear regression model
-    train_model_given_data_and_type(dram_train_features, dram_target_train, dram_test_features, dram_target_test, "DramEnergyConsumption")
+    train_model_given_data_and_type(dram_train_features, dram_target_train, dram_test_features, dram_target_test, "dram_model")
 
 
 # DEMO: Run python kepler_regression_model_tests.py (python -m tests.kepler_regression_model_tests) to test the linear regression models for Dram and Core Energy Consumption using mock data.


### PR DESCRIPTION
Before adding the new flask route for retrieving model weights and before implementing the Prometheus based pipeline, I noticed some important code changes that can make development for future contributors easier. First change I made was adding some decoupling between the flask server and the module for training the models called kepler_model_trainer.py (code that deals with directly handling the models are now placed in the kepler_model_trainer and code that deals with handling requests are strictly in the flask server). Second change I made was ensuring the model_type (which is for accessing the different linear regression trained models) was universal. Currently, we just have two models: core energy consumption and dram energy consumpion. For example, in one module, the model_types were CoreEnergyConsumption and DramEnergyConsumption. In another module, the model_types were core_model and dram_model. When Kepler makes a get request for the desired trained model, the acceptable model_types are core_model and dram_model. Thus for simplicity, I replaced  CoreEnergyConsumpion with core_model and DramEnergyConsumption with dram_model in all relevant modules. Followup changes include minor import statement removals and removing unnecessary code. After this refactoring, I intend to then push the new flask route which allows Kepler to retrieve model weights. 