### PR TITLE
Included WIP code using dummy prometheus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ From the project folder, run 'python -m tests.kepler_regression_model_tests' to 
 
 To test the routes that use the model, call python server.py. Available routes include '/models/<model_type>' and '/model-weights/<model_type>'. '/models/<model_type>' returns the saved model as a zip that needs to be extracted before being used. '/model-weights/<model_type>' returs the weights of a given model. Acceptable values for <model_type> are 'core_model' and 'dram_model'.
 
+Test tfio.experimental.IODataset.from_prometheus()
+
+Run './prometheus' with the given prometheus.yml file. Then run 'energy_scheduler.py' by calling 'python energy_scheduler.py'. The script will wait 5 seconds before scraping from prometheus endpoint just to make 5 seconds worth of data is retrieved. 

--- a/server/energy_scheduler.py
+++ b/server/energy_scheduler.py
@@ -27,6 +27,7 @@ def dummy_prometheus_pipeline():
 if __name__ == "__main__":
     #schedule.every().day.at("00:00").do(energy_prometheus_pipeline)
     #schedule.every(10).seconds.do(dummy_prometheus_pipeline)
+    time.sleep(5)
     dummy_prometheus_pipeline()
     #while True:
     #    schedule.run_pending()

--- a/server/energy_scheduler.py
+++ b/server/energy_scheduler.py
@@ -1,11 +1,12 @@
+from numpy import test
 import schedule
-from prometheus_datapipeline_functions import retrieve_and_clean_prometheus_energy_metrics, create_prometheus_core_dataset, create_prometheus_dram_dataset
+from prometheus_datapipeline_functions import retrieve_and_clean_prometheus_energy_metrics, create_prometheus_core_dataset, create_prometheus_dram_dataset, retrieve_dummy_prometheus_metrics
 from kepler_model_trainer import train_model_given_data_and_type
 import time
 
 #TODO: Test with Kepler on AWS
 
-# Temporary scheduler to scrape prometheus metrics once every day
+# Scheduler to scrape prometheus energy metrics once every day
 def energy_prometheus_pipeline():
     energy_data_dict = retrieve_and_clean_prometheus_energy_metrics()
     core_train, core_val, core_test = create_prometheus_core_dataset(energy_data_dict['cpu_architecture'], energy_data_dict['curr_cpu_cycles'], energy_data_dict['current_cpu_instructions'], energy_data_dict['curr_cpu_time'], energy_data_dict['curr_energy_in_core'] )
@@ -13,9 +14,21 @@ def energy_prometheus_pipeline():
     train_model_given_data_and_type(core_train, core_val, core_test, 'core_model')
     train_model_given_data_and_type(dram_train, dram_val, dram_test, 'dram_model')
 
+# Scheduler to scrape prometheus dummy test metrics every 5 seconds 
+def dummy_prometheus_pipeline():
+    test_dataset = retrieve_dummy_prometheus_metrics()
 
-schedule.every().day.at("00:00").do(energy_prometheus_pipeline)
+    refined_dataset = test_dataset.map(lambda _, y: y['prometheus']['localhost:9090']['go_memstats_alloc_bytes_total'])
+    for value in refined_dataset:
+        print("{}".format(value))
 
-while True:
-    schedule.run_pending()
-    time.sleep(1)
+        
+
+if __name__ == "__main__":
+    #schedule.every().day.at("00:00").do(energy_prometheus_pipeline)
+    #schedule.every(10).seconds.do(dummy_prometheus_pipeline)
+    dummy_prometheus_pipeline()
+    #while True:
+    #    schedule.run_pending()
+    #    time.sleep(1)
+   

--- a/server/prometheus.yml
+++ b/server/prometheus.yml
@@ -1,0 +1,29 @@
+# my global config
+global:
+  scrape_interval: 1s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 1s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/server/prometheus_datapipeline_functions.py
+++ b/server/prometheus_datapipeline_functions.py
@@ -1,14 +1,18 @@
+from hashlib import new
 import tensorflow_io as tfio
 import numpy as np
 import tensorflow as tf
 
 #TODO: Test with Kepler on AWS
 def scrape_prometheus_metrics(query, length, endpoint):
-    return tfio.experimental.IODataset.from_prometheus(query, length, endpoint=endpoint)
+    return tfio.experimental.IODataset.from_prometheus(query=query, length=length, endpoint=endpoint)
 
+#Testing using a Prometheus exporter which monitors itself for metrics
+def retrieve_dummy_prometheus_metrics():
+    return scrape_prometheus_metrics("go_memstats_alloc_bytes_total", 5, "http://localhost:9090")
 
 def retrieve_and_clean_prometheus_energy_metrics():
-    energy_metrics_dataset = scrape_prometheus_metrics("PLACEHOLDER", 100, "http://localhost:9090/metrics/")
+    energy_metrics_dataset = scrape_prometheus_metrics("PLACEHOLDER", 100, "http://localhost:9090/")
     # Retrieve all the desired energy related features in the form of tensors
     curr_cpu_cycles = []
     curr_cpu_instructions = []


### PR DESCRIPTION
As requested by Parul, a dummy prometheus server was set up to test the from_prometheus scraper. The prometheus.yml file is provided which just has prometheus monitor itself. Warning from_prometheus does not appear to be working on my end. I still made the WIP PR so other developers can try testing from_prometheus for themselves to see if it's an issue on my end only or if the tfio.experimental.IODataset.from_prometheus is unreliable and a new alternative must be set up (like with elasticsearch or with more primitive ways of scraping prometheus metrics). To test, run './prometheus' with the new yml file and then run energy_scheduler.py by calling 'python energy_scheduler.py'.