### PR TITLE
Deployment manifests for using model trainer as a side car 

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,3 +1,33 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kepler-model-server-pv
+  labels:
+    type: local
+    app.kubernetes.io/component: kepler-model-server-pv
+    app.kubernetes.io/name: kepler-model-server-pv
+spec:
+  storageClassName: default
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/mnt/data"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kepler-model-server-pvc
+  namespace: monitoring
+spec:
+  storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,7 +37,7 @@ metadata:
     app.kubernetes.io/component: model-server
     app.kubernetes.io/name: kepler-model-server
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/component: model-server
@@ -15,27 +45,30 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: kepler-model-server
+        app.kubernetes.io/component: model-server
         app.kubernetes.io/name: kepler-model-server
     spec:
       volumes:
       - name: models
-        hostPath:
-          path: /tmp/kepler-model-server
+        persistentVolumeClaim:
+          claimName: kepler-model-server-pvc
       containers:
       - name: kepler-model-server
-        image: quay.io/sustainable_computing_io/kepler_model_server_base:latest
+        image: quay.io/sustainable_computing_io/kepler_model_server:latest
         ports:
         - containerPort: 8100
         volumeMounts:
           - name: models
-            mountPath: /tmp/kepler-model-server/models
+            mountPath: /models
       - name: kepler-model-trainer
-        image: quay.io/sustainable_computing_io/kepler_model_server_base:latest
-        command: ["python",  "energy_scheduler.py'"]
+        image: quay.io/sustainable_computing_io/kepler_model_server:latest
+        command: ["python3.8",  "energy_scheduler.py"]
+        env:
+        - name: PROMETHEUS_ENDPOINT
+          value: "http://prometheus-k8s:9090/api/v1/query"
         volumeMounts:
           - name: models
-            mountPath: /tmp/kepler-model-server/models
+            mountPath: /models
 ---
 kind: Service
 apiVersion: v1
@@ -53,7 +86,4 @@ spec:
   ports:
   - name: http
     port: 8100
-    targetPort: http        
-
-
-
+    targetPort: http

--- a/server/kepler_model_trainer.py
+++ b/server/kepler_model_trainer.py
@@ -8,7 +8,7 @@ from keras import backend as K
 from keras.callbacks import History
 
 # Dict to map model type with filepath
-model_type_to_filepath = {"core_model": "models/core_model", "dram_model": "models/dram_model"}
+model_type_to_filepath = {"core_model": "/models/core_model", "dram_model": "/models/dram_model"}
 
 core_model_labels = {
                 "numerical_labels": ["curr_cpu_cycles", "current_cpu_instructions", "curr_cpu_time"],


### PR DESCRIPTION
Signed-off-by: Parul <parsingh@redhat.com>

Part of https://github.com/sustainable-computing-io/kepler-model-server/issues/16

This PR creates the manifest to run Kepler Model Server as a side car. The KMS queries prometheus to train/retrain power model