### PR TITLE
Finalized models, completed investigation into model weights and labe…

### DIFF
--- a/server/kepler_model_trainer.py
+++ b/server/kepler_model_trainer.py
@@ -222,11 +222,6 @@ def return_model_weights(model_type):
             final_dict = {"All_Weights": {"Numerical_Variables": numerical_weights_dict, "Categorical_Variables": categorical_weights_dict, "Bias_Weight": bias} }
             print(final_dict)
             return final_dict
-            # return this dict and the json.dumps it. Once this is done, push. update rmse issue ideally. 
-            # implement prometheus endpoint
-            # implement elastic search opentelemetry.
-            # medium issue b/c of investigation for next week to try and improve model for remse problem (setup test environ)
-            # start work on both scheduler and vpa next week (xl issue)
             
         raise FileNotFoundError("The desired trained model is valid, but the model has not been created/saved yet")
     else:

--- a/server/server.py
+++ b/server/server.py
@@ -39,16 +39,9 @@ def get_model(model_type='core_model'):
 @app.route('/model-weights/')
 def get_model_weights(model_type='core_model'):
     try:
-        #returned_coefficients = return_model_coefficients(model_type)
-        kernel_matrix, bias = return_model_weights(model_type)
-        #print(kernel_matrix)
-        #print(bias)
-        data = {
-            "kernel_matrix": kernel_matrix,
-            "bias": bias
-        }
+        model_weights_dict = return_model_weights(model_type)
         response = app.response_class(
-        response=json.dumps(data),
+        response=json.dumps(model_weights_dict),
         status=200,
         mimetype='application/json'
         )


### PR DESCRIPTION
…ls, implemented route for model weights and labels. Kepler model server can now return a json containing important labels and corresponding weights. Keras unfortunately does not explicitly show the coefficients and corresponding feature/label name. This is likely because the coefficients provided by keras were not really intended to be used externally. However, after investigation, the order that the weights are shown by keras can be predicted by order of which the labels are fed into the model and by the order in which vocabulary is listed for categorical labels. Numerical labels also have mean and variance since all numerical labels are normalized since numerical values can get extremely large. Note that all categorical labels are one hot encoded. For instance, cpu_architecture has 8 options. Also, 'UNK' (unknown vocabulary variable) was excluded from the cpu_architecture vocabulary. Before merging this PR, consider whether 'UNK' is needed or not as vocab that is not recognized by cpu_architecture will result in an error. Also, the current vocab used by cpu architecture is "Sandy Bridge", "Ivy Bridge", "Haswell", "Broadwell", "Sky Lake", "Cascade Lake", "Coffee Lake", "Alder Lake". Please let me know whether some cpu_architectures are missing.   