### PR TITLE
add train pipeline guideline for compatability to kepler-estimator 

### DIFF
--- a/doc/train_pipeline.md
+++ b/doc/train_pipeline.md
@@ -1,0 +1,56 @@
+# Trainning Pipeline
+The model server contains a collection of trainning pipelines in a unified format defined in `server/train/pipeline.py`.
+
+Each pipeline can be categorized into one of the group defined in `/server/train/train_types.py` according to its train features.
+
+
+Group Name|Features
+---|---
+Full|WORKLOAD_FEATURES + SYSTEM_FEATURES
+WorkloadOnly|WORKLOAD_FEATURES
+CounterOnly|COUNTER_FEAUTRES
+CgroupOnly|CGROUP_FEATURES + IO_FEATURES
+BPFOnly|BPF_FEATURES
+KubeletOnly|KUBELET_FEATURES
+
+
+
+*Note:* WORKLOAD_FEATURES includes COUNTER_FEAUTRES, CGROUP_FEATURES + IO_FEATURES, BPF_FEATURES and KUBELET_FEATURES.
+
+
+Features|Kepler exporting labels in `pod_energy_stat` metric
+---|---
+COUNTER_FEAUTRES| - curr_cache_miss<br>- curr_cpu_cycles<br>- curr_cpu_instr
+CGROUP_FEATURES+IO_FEATURES| - curr_cgroupfs_cpu_usage_us<br>- curr_cgroupfs_memory_usage_byte<br>- curr_cgroupfs_system_cpu_usage_us<br>- curr_cgroupfs_user_cpu_usage_us<br>-curr_bytes_read<br>-curr_bytes_writes
+BPF_FEATURES| - curr_cpu_time
+KUBELET_FEATURES|- container_cpu_usage_seconds_total<br>- container_memory_working_set_bytes
+---
+
+### Guideline to define a new pipeline class
+refer to [pipeline.py](../server/train/pipeline.py)
+1. Define the following attributes.
+
+    Attribute|Description
+    ---|---
+    *model_name*| unique ID inside the feature group
+    *model_class* | class of modeling approach, currently support only `keras` and `scikit` for Keras Model and Scikit-learn Regressor, respectively.
+    *model_file*| model filename, this will be load accoring to *model_class* (e.g., `model.h5` for `keras`, `model.sav` for `scikit`)
+    *features*| list of train features referring to kepler exporting labels in `pod_energy_stat` metric
+
+
+2. implement `train(self, pod_stat_data, node_stat_data, freq_data, pkg_data)`
+
+    Argument|Prometheus Metric|Description
+    ---|---|---
+    *pod_stat_data*| `pod_energy_stat` |resource usage per pod
+    *node_stat_data* | `node_energy_stat`|resource usage and measured energy per node
+    *freq_data*| `node_cpu_scaling_frequency_hertz`|CPU frequency per core per node
+    *pkg_data*| `node_package_energy_millijoule`|measured energy per package per node
+
+    expected actions in this function:
+    - train a prediction model from the given data
+    - update the trained model and its metadata if improved
+      - metadata attributes must be compatible with [kepler-estimator](https://github.com/sustainable-computing-io/kepler-estimator/blob/d351cbfadd67f5f270f223c2e7ebeb225f06a070/src/model/load.py#L17))
+      - input of the model will be array in a shape (m, n) where m = number of pod, n = number of model features
+      - output of the model must a single power per pod
+

--- a/server/train/__init__.py
+++ b/server/train/__init__.py
@@ -1,0 +1,1 @@
+from train.kepler_model_trainer import generate_core_regression_model, train_model_given_data_and_type

--- a/server/train/kepler_model_trainer.py
+++ b/server/train/kepler_model_trainer.py
@@ -1,0 +1,322 @@
+import tensorflow as tf
+from keras.models import load_model
+from keras import layers, Model, Input, metrics, optimizers
+import numpy as np
+import os
+import shutil
+from keras import backend as K
+from keras.callbacks import History
+
+from train_types import CATEGORICAL_LABEL_TO_VOCAB
+# Dict to map model type with filepath
+model_type_to_filepath = {"core": "/models/core_model", "dram": "/models/dram_model"}
+
+core_model_labels = {
+                "numerical_labels": ["curr_cpu_cycles", "curr_cpu_instr", "curr_cpu_time"],
+                "categorical_string_labels": ["cpu_architecture"] }
+
+dram_model_labels = {
+                    "numerical_labels": ["container_memory_working_set_bytes", "curr_cache_miss"],
+                    "categorical_string_labels": ["cpu_architecture"]}
+
+
+
+
+def coeff_determination(y_true, y_pred):
+    SS_res =  K.sum(K.square( y_true-y_pred )) 
+    SS_tot = K.sum(K.square( y_true - K.mean(y_true) ) ) 
+    return ( 1 - SS_res/(SS_tot + K.epsilon()) )
+
+# Generates a Core regression model which predicts curr_energy_in_core given
+# numerical features (curr_cpu_cycles, curr_cpu_instructions, curr_cpu_time).
+# Consumes a tensorflow dataset with no missing data and all required features and 
+# target. This Regression model will be saved on server.
+def generate_core_regression_model(core_train_dataset: tf.data.Dataset) -> Model:
+    prefix = 'core_'
+    all_features_to_modify = []
+    input_list = []
+    #normalizing numerical features with given dataset
+    for numerical_column in core_model_labels["numerical_labels"]:
+        new_input = Input(shape=(1,), name=prefix + numerical_column) # single list with one constant
+        new_normalizer_name = "normalization_" + numerical_column
+        new_normalizer = layers.Normalization(axis=None, name=new_normalizer_name)
+        new_normalizer.adapt(core_train_dataset.map(lambda x, y: x[prefix + numerical_column]))
+        all_features_to_modify.append(new_normalizer(new_input))
+        input_list.append(new_input)
+    # encoding categorical feature with given data immediately (can also write this as a new model)
+    for categorical_column in core_model_labels["categorical_string_labels"]:
+        new_input = Input(shape=(1, ), name=prefix + categorical_column, dtype='string') # single list with one constant
+        new_int_index = layers.StringLookup(vocabulary=CATEGORICAL_LABEL_TO_VOCAB[categorical_column], num_oov_indices=0)
+        #new_int_index.adapt(core_train_dataset.map(lambda x, y: x[categorical_column]))
+        new_layer = layers.CategoryEncoding(num_tokens=new_int_index.vocabulary_size(), output_mode='one_hot') # no relationship between categories
+        all_features_to_modify.append(new_layer(new_int_index(new_input)))
+        input_list.append(new_input)
+    
+    all_features = layers.concatenate(all_features_to_modify)
+    single_regression_layer = layers.Dense(units=1, activation='linear', name="core_linear_regression_layer")(all_features)
+    new_linear_model = Model(input_list, single_regression_layer)
+    new_linear_model.compile(optimizer=optimizers.Adam(learning_rate=0.5), loss='mae', metrics=[coeff_determination, metrics.RootMeanSquaredError(), metrics.MeanAbsoluteError()])
+    return new_linear_model
+    
+    #normalizer = layers.Normalization(axis=-1)
+    #normalizer.adapt(np.array(train_features))
+    #created a linear regression model with normalized features
+    #new_linear_model = Sequential([
+    #    normalizer,
+    #    layers.Dense(units=1) #len(train_features instead?)
+    #])
+    #new_linear_model.compile(optimizer=tf.optimizers.Adam(learning_rate=0.1), loss='mean_squared_error')
+    #return new_linear_model
+
+
+def generate_dram_regression_model(dram_train_dataset: tf.data.Dataset) -> Model:
+    prefix = 'dram_'
+    all_features_to_modify = []
+    input_list = []
+    #normalizing numerical features with given dataset
+    for numerical_column in dram_model_labels["numerical_labels"]:
+        new_input = Input(shape=(1,), name=prefix + numerical_column) # single list with one constant
+        new_normalizer_name = "normalization_" + numerical_column
+        new_normalizer = layers.Normalization(axis=None, name=new_normalizer_name)
+        new_normalizer.adapt(dram_train_dataset.map(lambda x, y: x[prefix + numerical_column]))
+        all_features_to_modify.append(new_normalizer(new_input))
+        input_list.append(new_input)
+    # encoding categorical feature with given data immediately (can also write this as a new model)
+    for categorical_column in dram_model_labels["categorical_string_labels"]:
+        new_input = Input(shape=(1, ), name=prefix + categorical_column, dtype='string') # single list with one constant
+        new_int_index = layers.StringLookup(vocabulary=CATEGORICAL_LABEL_TO_VOCAB[categorical_column], num_oov_indices=0)
+        #new_int_index.adapt(dram_train_dataset.map(lambda x, y: x[categorical_column]))
+        new_layer = layers.CategoryEncoding(num_tokens=new_int_index.vocabulary_size(), output_mode='one_hot') # no relationship between categories
+        all_features_to_modify.append(new_layer(new_int_index(new_input)))
+        input_list.append(new_input)
+    
+    all_features = layers.concatenate(all_features_to_modify)
+    single_regression_layer = layers.Dense(units=1, activation='linear', name="dram_linear_regression_layer")(all_features)
+
+    new_linear_model = Model(input_list, single_regression_layer)
+
+    new_linear_model.compile(optimizer=optimizers.Adam(learning_rate=0.5), loss='mae', metrics=[coeff_determination, metrics.RootMeanSquaredError(), metrics.MeanAbsoluteError()])
+    return new_linear_model
+
+
+# Helper function to verify model_type is valid, check whether the model has been created or not,
+# and create a filepath to the model.
+# Returns type (str, Bool) where str is the filepath to the model_type or None if the model_type
+# is invalid, and Bool is True if the model of the desired type was already created and False if the model
+# of the desired type has not been created. If str is None, then Bool is False.
+def return_model_filepath(model_type):
+    if model_type in model_type_to_filepath:
+        filepath = os.path.dirname(__file__) + model_type_to_filepath[model_type]
+        return filepath, os.path.exists(filepath)
+        #if os.path.exists(filepath):
+        #    return filepath, True
+        #return filepath, False
+    return None, False
+        
+# This function creates a new model and trains it given train_features, train_labels, test_features, test_labels.
+# If the desired model already exists, it will be retrained, refitted, evaluated and saved.
+# takes dataframe
+def train_model_given_data_and_type(new_model, train_dataset, validation_dataset, test_dataset, model_type):
+    # TODO: Include Demo using excel data - returns evaluation details and coefficients
+    history = History()
+    new_model.fit(train_dataset, epochs=5, validation_data=validation_dataset, callbacks=[history])
+    loss_result, r_squared, rmse_metric, mae_metric = new_model.evaluate(test_dataset)
+    # TODO: Include While loop to ensure loss_result is within acceptable ranges (Save only if loss is acceptable)
+
+    print("Mean Squared Error Loss: " + str(loss_result))
+    print("Root Mean Squared Error Loss metric: " + str(rmse_metric))
+    print("Mean Absolute Error Loss metric: " + str(mae_metric))
+    print("Correlation of Determination:" + str(r_squared))
+    print("Training MSE Results per epoch: {}".format(history.history['loss']))
+    print("Training RMSE Results per epoch: {}".format(history.history['root_mean_squared_error']))
+    print("Training Correlation Coefficient per epoch: {}".format(history.history['coeff_determination']))
+    print("Validation MSE per epoch: {}".format(history.history['val_loss']))
+    print("Validation RMSE per epoch: {}".format(history.history['val_root_mean_squared_error']))
+    print("Validation Correlation Coefficient per epoch: {}".format(history.history['val_coeff_determination']))
+    # new_model.save(filepath, save_format='tf', include_optimizer=True)
+    #try:
+    #    returned_model = load_model('models/core_model.h5')
+        # after retrieving saved model, call fit
+        # returned_model.fit(train_features, train_labels, epochs=100)
+    #    save_model(returned_model, 'models/core_model.h5')
+
+    #except IOError:
+        # indicates file does not exist
+    #    new_model = generate_regression_model(train_features)
+        # new_model.fit(train_features, train_labels, epochs=100)
+    #    save_model(returned_model, 'models/core_model.h5')
+    return new_model, loss_result, rmse_metric, mae_metric
+
+
+# This function archives the SavedModel according to model_type. It returns the filepath to zipped SavedModel
+# and the filename (which is just the model type with .zip appended to the end)
+def archive_saved_model(model_type):
+    filepath, model_exists = return_model_filepath(model_type)
+    if filepath is None:
+        raise ValueError("Provided Model Type is invalid and/or not included")
+    if not model_exists:
+        raise FileNotFoundError("The desired trained model is valid, but the model has not been created/saved yet")
+    
+    shutil.make_archive(filepath, 'zip', filepath)
+    # return archived zipped filepath directory
+    return os.path.dirname(__file__) + '/models/', model_type + '.zip'
+
+
+def create_numerical_labels_weights_relation(numerical_labels, numerical_weights, mean_variance_for_each_label):
+    return {numerical_labels[i]: {'weight': weight, "mean": mean_variance_for_each_label[i][0], "variance": mean_variance_for_each_label[i][1]} for i, weight in enumerate(numerical_weights)}
+
+
+def create_categorical_vocab_weights_relation(categorical_labels, list_of_all_categorical_labels_vocab, list_of_all_categorical_labels_weights):
+    return {label: {list_of_all_categorical_labels_vocab[i][j]: {'weight': list_of_all_categorical_labels_weights[i][j]} for j in range(len(list_of_all_categorical_labels_vocab[i]))} for i, label in enumerate(categorical_labels)}
+
+# Returns the weights and bias from the desired model.
+def return_model_weights(model_type):
+    filepath, model_exists = return_model_filepath(model_type)
+    if filepath is not None:
+        if model_exists:
+            # Retrieve Model
+            returned_model = load_model(filepath, custom_objects={'coeff_determination': coeff_determination})
+            #TODO: In future, create a dict to divide the model algorithm type (Linear, NN, etc.) for better
+            # abstraction and to avoid repeat code. Currently, all models are Regression with Normalized Numerical
+            # Labels and String Categorical Labels. All Models have the same name for the regression layer and same naming
+            # convention for normalized preprocessing layers.
+
+            # Retrieve Coefficients
+            kernel_matrix = returned_model.get_layer(name=model_type +"_linear_regression_layer").get_weights()[0]
+            bias = returned_model.get_layer(name=model_type +"linear_regression_layer").get_weights()[1][0].item()
+            weights_list = np.ndarray.tolist(np.squeeze(kernel_matrix))
+            print(weights_list)
+            print(bias)
+            if model_type == "core":
+                # Retrieve Numerical Labels for Core Model
+                numerical_labels = core_model_labels["numerical_labels"]
+                # Retrieve Categorical Labels for Core Model
+                categorical_labels = core_model_labels["categorical_string_labels"]
+            if model_type == "dram":
+                # Retrieve Numerical Labels for Core Model
+                numerical_labels = dram_model_labels["numerical_labels"]
+                # Retrieve Categorical Labels for Core Model
+                categorical_labels = dram_model_labels["categorical_string_labels"]
+                
+            # Numerical Weights
+            start_index = len(numerical_labels)
+            numerical_weights = weights_list[0:start_index]
+            # Normalization Weights
+            normalization_weights = []
+            for numerical_label in numerical_labels:
+                name = "normalization_" + numerical_label
+                normalization_weight = np.float_(returned_model.get_layer(name=name).get_weights())
+                normalization_weights.append(normalization_weight)
+
+            # Numerical Label and Weights Dict
+            numerical_weights_dict = create_numerical_labels_weights_relation(numerical_labels, numerical_weights, normalization_weights)
+            
+            # Categorical Weights
+            list_of_all_categorical_labels_vocab = []
+            list_of_all_categorical_labels_weights = []
+            for categorical_label in categorical_labels:
+                categorical_label_vocab = CATEGORICAL_LABEL_TO_VOCAB[categorical_label]
+                list_of_all_categorical_labels_vocab.append(categorical_label_vocab)
+                end_index = start_index + len(categorical_label_vocab)
+                categorical_label_weights = weights_list[start_index:end_index]
+                list_of_all_categorical_labels_weights.append(categorical_label_weights)
+                start_index = end_index
+            
+            #Categorical Label and Weights Dict
+            categorical_weights_dict = create_categorical_vocab_weights_relation(categorical_labels, list_of_all_categorical_labels_vocab, list_of_all_categorical_labels_weights)
+            # Combine all features and weights into a single dictionary
+            final_dict = {"All_Weights": {"Numerical_Variables": numerical_weights_dict, "Categorical_Variables": categorical_weights_dict, "Bias_Weight": bias} }
+            return final_dict
+            
+        raise FileNotFoundError("The desired trained model is valid, but the model has not been created/saved yet")
+    else:
+        raise ValueError("Provided Model Type is invalid and/or not included")
+
+
+# Test function
+def return_model_test_coefficients(model_type):
+    filepath, model_exists = return_model_filepath(model_type)
+    if filepath is not None:
+        if model_exists:
+            # Retrieve coefficients
+            #returned_model = load_model(filepath)
+            #for layer in returned_model.layers: print(layer.get_config(), layer.get_weights())
+            #print(returned_model.get_weights())
+            #for layer in returned_model.layers:
+            #    print(layer.name)
+            #    if(layer.name == "string_lookup"):
+            #        print(layer.get_vocabulary())
+            #    if(layer.name == "concatenate"):
+            #        print(layers.Concatenate(layer))
+            #    if(layer.name == "linear_regression_layer"):
+            #        print(layer.variables)
+            #        print(layer.weights)
+            return "Placeholder"
+        raise FileNotFoundError("The desired trained model is valid, but the model has not been created/saved yet")
+    else:
+        raise ValueError("Provided Model Type is invalid and/or not included")
+
+
+#def train_dram_model(train_features, train_labels, test_features, test_labels):
+    # TODO: Include Demo using dataset in the form of an excel file - returns evaluation details and coefficients    
+    #try:
+    #    returned_model = load_model('models/dram_model.h5')
+        # after retrieving saved model, train and evaluate
+        # returned_model.fit(train_features, train_labels, epochs=100)
+        # returned_model.evaluate(test_features, test_labels, verbose=0)
+    #    save_model(returned_model, 'models/dram_model.h5')
+
+    #except IOError:
+        # indicates file does not exist
+    #    new_model = generate_regression_model(train_features)
+        # new_model.fit(train_features, train_labels, epochs=100)
+        # new_model.evaluate(test_features, test_labels, verbose=0)
+    #    save_model(returned_model, 'models/dram_model.h5')
+
+def create_prometheus_core_dataset(cpu_architecture, curr_cpu_cycles, curr_cpu_instructions, curr_cpu_time, curr_energy_in_core): #query: str, length: int, endpoint: str
+    prefix = 'core_'
+    # Create Desired Datasets for Core Model
+    features_dict_core = {prefix + 'cpu_architecture': cpu_architecture, prefix + 'curr_cpu_cycles': curr_cpu_cycles, prefix + 'curr_cpu_instr': curr_cpu_instructions, prefix + 'curr_cpu_time': curr_cpu_time}
+    refined_dataset_core = tf.data.Dataset.from_tensor_slices((features_dict_core, curr_energy_in_core))
+
+    refined_dataset_core_size = refined_dataset_core.cardinality().numpy()
+
+    assert(refined_dataset_core_size >= 5)
+    train_size = int(refined_dataset_core_size*0.6)
+    val_size = int(refined_dataset_core_size*0.2)
+    train_dataset_core = refined_dataset_core.take(train_size)
+    val_dataset_core = refined_dataset_core.skip(train_size).take(val_size)
+    test_dataset_core = refined_dataset_core.skip(train_size).skip(val_size)
+    
+    train_dataset_core = train_dataset_core.shuffle(buffer_size=train_size).repeat(4).batch(32)
+    val_dataset_core = val_dataset_core.batch(32)
+    test_dataset_core = test_dataset_core.batch(32)
+
+    return train_dataset_core, val_dataset_core, test_dataset_core
+
+
+def create_prometheus_dram_dataset(cpu_architecture, curr_cache_misses, curr_resident_memory, curr_energy_in_dram):
+    prefix = 'dram_'
+    # Create Desired Dataset for Dram Model
+    features_dict_dram = {prefix + 'cpu_architecture': cpu_architecture, prefix + 'container_memory_working_set_bytes': curr_resident_memory, prefix + 'curr_cache_miss': curr_cache_misses}
+    refined_dataset_dram = tf.data.Dataset.from_tensor_slices((features_dict_dram, curr_energy_in_dram))
+    refined_dataset_dram_size = refined_dataset_dram.cardinality().numpy()
+    assert(refined_dataset_dram_size >= 5)
+    train_size = int(refined_dataset_dram_size*0.6)
+    val_size = int(refined_dataset_dram_size*0.2)
+    train_dataset_dram = refined_dataset_dram.take(train_size)
+    val_dataset_dram = refined_dataset_dram.skip(train_size).take(val_size)
+    test_dataset_dram = refined_dataset_dram.skip(train_size).skip(val_size)
+    
+    train_dataset_dram = train_dataset_dram.shuffle(buffer_size=train_size).repeat(4).batch(32)
+    val_dataset_dram = val_dataset_dram.batch(32)
+    test_dataset_dram = test_dataset_dram.batch(32)
+
+    return train_dataset_dram, val_dataset_dram, test_dataset_dram
+
+def merge_model(core_model, dram_model):
+    # concat_layer = layers.Concatenate([core_model, dram_model])
+    # output = layers.Lambda(tf.reduce_sum, arguments=dict(axis=1))(concat_layer)
+    output = layers.Add()([core_model.output, dram_model.output])
+    model = Model(inputs=core_model.inputs + dram_model.inputs, outputs=output)
+    return model

--- a/server/train/keras_pipe.py
+++ b/server/train/keras_pipe.py
@@ -1,0 +1,131 @@
+from random import random
+from pipeline import TrainPipeline
+from train_types import FeatureGroup, FeatureGroups
+from kepler_model_trainer import train_model_given_data_and_type, create_prometheus_core_dataset, create_prometheus_dram_dataset, coeff_determination
+from kepler_model_trainer import generate_core_regression_model, generate_dram_regression_model
+from kepler_model_trainer import dram_model_labels, core_model_labels
+from kepler_model_trainer import merge_model
+from keras.models import load_model
+import pickle
+import tensorflow as tf
+
+import os
+import numpy as np
+
+MODEL_NAME = 'KerasLR_Full'
+MODEL_CLASS = 'keras'
+MODEL_FILENAME = MODEL_NAME + '.h5'
+FE_FILE = 'merge.pkl'
+
+CORE_MODEL_TYPE = 'core'
+DRAM_MODEL_TYPE = 'dram'
+
+class KerasFullPipelineFeatureTransformer():
+    def __init__(self, features, dram_model_labels, core_model_labels):
+        self.features = features
+        self.core_numerical_indexes = [self.features.index(label) for label in core_model_labels['numerical_labels']]
+        self.dram_numerical_indexes = [self.features.index(label) for label in dram_model_labels['numerical_labels']]
+        self.core_categorical_indexes = [self.features.index(label) for label in core_model_labels['categorical_string_labels']]
+        self.dram_categorical_indexes = [self.features.index(label) for label in core_model_labels['categorical_string_labels']]
+
+    def transform(self, x_values):
+        inputs = []
+        for core_index in self.core_numerical_indexes:
+            core_values = x_values[:,core_index:core_index+1].astype(np.float32)
+            inputs.append(tf.cast(core_values, tf.float32))
+        for core_index in self.core_categorical_indexes:
+            inputs.append(tf.cast(x_values[:,core_index:core_index+1], tf.string))
+        for dram_index in self.dram_numerical_indexes:
+            dram_values = x_values[:,dram_index:dram_index+1].astype(np.float32)
+            inputs.append(tf.cast(dram_values, tf.float32))
+        for dram_index in self.dram_categorical_indexes:
+            inputs.append(tf.cast(x_values[:,dram_index:dram_index+1], tf.string))
+        return inputs
+
+class KerasFullPipeline(TrainPipeline):
+    def __init__(self):
+        self.mse = None
+        self.mse_val = None
+        self.mae = None
+        self.mae_val = None
+
+        super(KerasFullPipeline, self).__init__(MODEL_NAME, MODEL_CLASS, MODEL_FILENAME, FeatureGroups[FeatureGroup.Full])
+        self.fe = KerasFullPipelineFeatureTransformer(self.features, dram_model_labels, core_model_labels)
+        fe_file_path = os.path.join(self.save_path, FE_FILE)
+        with open(fe_file_path, 'wb') as f:
+            pickle.dump(self.fe, f)
+            self.fe_files = [FE_FILE]
+
+    def train(self, pod_stat_data, node_stat_data, freq_data, pkg_data):
+        if int(node_stat_data['node_curr_energy_in_pkg_joule'].sum()) == 0:
+            # cannot train with package-level info
+            return
+        core_train, core_val, core_test = create_prometheus_core_dataset(node_stat_data['cpu_architecture'], node_stat_data['curr_cpu_cycles'], node_stat_data['curr_cpu_instr'], node_stat_data['curr_cpu_time'], node_stat_data['node_curr_energy_in_core_joule'])
+        dram_train, dram_val, dram_test = create_prometheus_dram_dataset(node_stat_data['cpu_architecture'], node_stat_data['curr_cache_miss'], node_stat_data['container_memory_working_set_bytes'], node_stat_data['node_curr_energy_in_dram_joule'])
+        core_model = self.load_model(core_train, CORE_MODEL_TYPE)
+        dram_model = self.load_model(dram_train, DRAM_MODEL_TYPE)
+        core_model, _, _, core_mae_metric = train_model_given_data_and_type(core_model, core_train, core_val, core_test, CORE_MODEL_TYPE)
+        dram_model, _, _, dram_mae_metric = train_model_given_data_and_type(dram_model, dram_train, dram_val, dram_test, DRAM_MODEL_TYPE)
+        core_model.save(self._get_model_path(CORE_MODEL_TYPE), include_optimizer=True)
+        dram_model.save(self._get_model_path(DRAM_MODEL_TYPE), include_optimizer=True)
+        merged_model = merge_model(core_model, dram_model)
+        merged_model.save(self._get_model_path(MODEL_NAME), include_optimizer=True)
+        metadata = dict()
+        metadata['mae'] = core_mae_metric + dram_mae_metric
+        self.update_metadata(metadata)
+
+    def _get_model_path(self, model_type):
+        return os.path.join(self.save_path, model_type + ".h5")
+
+    def load_model(self, train_dataset, model_type):
+        filepath = self._get_model_path(model_type)
+        model_exists = os.path.exists(filepath)
+        if model_exists:
+            new_model = load_model(filepath, custom_objects={'coeff_determination': coeff_determination})
+        elif model_type == CORE_MODEL_TYPE:
+            new_model = generate_core_regression_model(train_dataset)
+        elif model_type == DRAM_MODEL_TYPE:
+            new_model = generate_dram_regression_model(train_dataset)
+        else:
+            "wrong type: " + model_type
+        return new_model
+
+    def predict(self, x_values):
+        print(x_values.shape)
+        fe_filepath = os.path.join(self.save_path, FE_FILE)
+        fe_item = pickle.load(open(fe_filepath, 'rb'))
+        transformed_values = fe_item.transform(x_values)
+        model_filepath = os.path.join(self.save_path, MODEL_FILENAME)
+        merged_model = load_model(model_filepath, compile=False)
+        result = merged_model.predict(transformed_values)
+        print(result)
+
+
+if __name__ == '__main__':
+    from train_types import WORKLOAD_FEATURES, SYSTEM_FEATURES, CATEGORICAL_LABEL_TO_VOCAB, NODE_STAT_POWER_LABEL
+    import pandas as pd
+    import numpy as np
+    item = dict()
+
+    for f in WORKLOAD_FEATURES:
+        item[f] = random()
+    for f in SYSTEM_FEATURES:
+        if f in CATEGORICAL_LABEL_TO_VOCAB:
+            item[f] = CATEGORICAL_LABEL_TO_VOCAB[f][0]
+        else:
+            item[f] = random()
+    for l in NODE_STAT_POWER_LABEL:
+        item[l] = random()*1000
+
+    data_items = [item]
+    node_stat_data = pd.DataFrame(data_items)
+    for f in WORKLOAD_FEATURES:
+        node_stat_data[f] = node_stat_data[f].astype(np.float32)
+    for f in SYSTEM_FEATURES:
+        if f not in CATEGORICAL_LABEL_TO_VOCAB:
+            node_stat_data[f] = node_stat_data[f].astype(np.float32)
+
+    node_stat_data = pd.concat([node_stat_data]*10, ignore_index=True)
+    pipeline = KerasFullPipeline()
+    pipeline.train(None, node_stat_data, None, None)
+    pipeline.predict(node_stat_data[pipeline.features].values)

--- a/server/train/pipeline.py
+++ b/server/train/pipeline.py
@@ -1,0 +1,54 @@
+from abc import ABCMeta, abstractmethod
+from train_types import FeatureGroup, get_feature_group
+
+import os
+import json
+
+TRAIN_MODEL_PATH_ENV = 'TRAIN_MODEL_PATH'
+METADATA_FILENAME = 'metadata.json'
+
+if TRAIN_MODEL_PATH_ENV not in os.environ:
+    model_path = os.path.join(os.path.dirname(__file__), 'local')
+else:
+    model_path = os.getenv(TRAIN_MODEL_PATH_ENV)
+
+if not os.path.exists(model_path):
+    os.mkdir(model_path)
+
+for g in FeatureGroup:
+    group_path = os.path.join(model_path, g.name)
+    if not os.path.exists(group_path):
+        os.mkdir(group_path)
+
+class TrainPipeline(metaclass=ABCMeta):
+    def __init__(self, model_name, model_class, model_file, features):
+        self.model_name = model_name
+        self.model_class = model_class
+        self.model_file = model_file
+        self.features = features
+        self.model_group = get_feature_group(features)
+        group_path = os.path.join(model_path, self.model_group.name)
+        print(group_path)
+        self.save_path = os.path.join(group_path, self.model_name)
+        if not os.path.exists(self.save_path):
+            os.mkdir(self.save_path)
+
+    def update_metadata(self, item):
+        print('update metadata')
+        item['model_name'] = self.model_name
+        item['model_class'] = self.model_class
+        item['model_file'] = self.model_file
+        item['features']= self.features
+        item['fe_files'] = [] if not hasattr(self, 'fe_files') else self.fe_files
+        self.metadata = item
+        metadata_file = os.path.join(self.save_path, METADATA_FILENAME)
+        with open(metadata_file, "w") as f:
+            json.dump(item, f)
+        
+
+    @abstractmethod
+    def train(self, pod_stat_data, node_stat_data, freq_data, pkg_data):
+        return NotImplemented
+
+    def get_model_specific_metadata(self):
+        return dict()

--- a/server/train/train_types.py
+++ b/server/train/train_types.py
@@ -1,0 +1,66 @@
+###########################################################
+## types.py
+## 
+## defines
+## - collection of features
+## - feature groups
+## - power labels
+##
+###########################################################
+
+import enum
+import random
+
+SYSTEM_FEATURES = ["cpu_architecture"]
+
+COUNTER_FEAUTRES = ["curr_cache_miss", "curr_cpu_cycles", "curr_cpu_instr"]
+CGROUP_FEATURES = ["curr_cgroupfs_cpu_usage_us", "curr_cgroupfs_memory_usage_bytes", "curr_cgroupfs_system_cpu_usage_us", "curr_cgroupfs_user_cpu_usage_us"]
+IO_FEATURES = ["curr_bytes_read", "curr_bytes_writes"]
+BPF_FEATURES = ["curr_cpu_time"]
+KUBELET_FEATURES =['container_cpu_usage_seconds_total', 'container_memory_working_set_bytes']
+WORKLOAD_FEATURES = COUNTER_FEAUTRES + CGROUP_FEATURES + IO_FEATURES + BPF_FEATURES + KUBELET_FEATURES
+
+CATEGORICAL_LABEL_TO_VOCAB = {
+                    "cpu_architecture": ["Sandy Bridge", "Ivy Bridge", "Haswell", "Broadwell", "Sky Lake", "Cascade Lake", "Coffee Lake", "Alder Lake"] 
+                    }
+
+NODE_STAT_POWER_LABEL = ["node_curr_energy_in_pkg_joule", "node_curr_energy_in_core_joule", "node_curr_energy_in_dram_joule", "node_curr_energy_in_uncore_joule", "node_curr_energy_in_gpu_joule", "node_curr_energy_in_other_joule"]
+
+class FeatureGroup(enum.Enum):
+   Full = 1
+   WorkloadOnly = 2
+   CounterOnly = 3
+   CgroupOnly = 4
+   BPFOnly = 5
+   KubeletOnly = 6
+   Unknown = 99
+
+def sort_features(features):
+    sorted_features = features.copy()
+    sorted_features.sort()
+    return sorted_features
+
+FeatureGroups = {
+    FeatureGroup.Full: sort_features(WORKLOAD_FEATURES + SYSTEM_FEATURES),
+    FeatureGroup.WorkloadOnly: sort_features(WORKLOAD_FEATURES),
+    FeatureGroup.CounterOnly: sort_features(COUNTER_FEAUTRES),
+    FeatureGroup.CgroupOnly: sort_features(CGROUP_FEATURES + IO_FEATURES),
+    FeatureGroup.BPFOnly: sort_features(BPF_FEATURES),
+    FeatureGroup.KubeletOnly: sort_features(KUBELET_FEATURES)
+}
+
+def get_feature_group(features):
+    sorted_features = sort_features(features)
+    for g, g_features in FeatureGroups.items():
+        print(g_features, features)
+        if sorted_features == g_features:
+            return g
+    return FeatureGroup.Unknown
+
+if __name__ == '__main__':
+    for g, g_features in FeatureGroups.items():
+        shuffled_features = g_features.copy()
+        random.shuffle(shuffled_features)
+        get_group = get_feature_group(shuffled_features)
+        assert get_group == g, "must be " + str(g)
+    assert get_feature_group([]) == FeatureGroup.Unknown, "must be unknown"


### PR DESCRIPTION
This PR introduces a guideline and abstract pipeline class to build a train pipeline that is compatible to kepler-estimator and new exporting prometheus metrics.
Please check the [train_pipeline.md](https://github.com/sunya-ch/kepler-model-server/blob/train-1/doc/train_pipeline.md) for detail.

Notes: I reused the existing training function for defining a training pipeline example in [keras_pipe.py](https://github.com/sunya-ch/kepler-model-server/blob/train-1/server/train/keras_pipe.py). 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>