### PR TITLE
functions to configurable parameters and shared paths

### DIFF
--- a/server/util/config.py
+++ b/server/util/config.py
@@ -1,0 +1,44 @@
+#################################################
+# config.py
+#
+# getConfig: return value set by configuration 
+#            which can be from config map or environment variable
+#            if not provided, return default value
+# getPath:   return path relative to mount path
+#            create new if not exists
+#            mount path is set by configuration
+#            if mount path cannot be write, 
+#            set to local folder (/server)
+#
+#################################################
+
+import os
+
+# must be writable (for shared volume mount)
+MNT_PATH = "/mnt"
+# can be read only (for configmap mount)
+CONFIG_PATH = "/etc/config"
+
+def getConfig(key, default):
+    # check configmap path
+    file = os.path.join(CONFIG_PATH, key)
+    if os.path.exists(file):
+        with open(file, "r") as f:
+            return f.read()
+    # check env
+    return os.getenv(key, default)
+
+def getPath(subpath):
+    path = os.path.join(MNT_PATH, subpath)
+    if not os.path.exists(path):
+        os.mkdir(path)
+    return path
+
+# update value from environment if exists
+MNT_PATH = getConfig('MNT_PATH', MNT_PATH)
+if not os.path.exists(MNT_PATH) or not os.access(MNT_PATH, os.W_OK):
+    # use local path if not exists or cannot write
+    MNT_PATH = os.path.join(os.path.dirname(__file__), '..')
+print("mount path: ", MNT_PATH)
+
+CONFIG_PATH = getConfig('CONFIG_PATH', CONFIG_PATH)


### PR DESCRIPTION
This PR implements functions to handle two environment configurations.

1. configurable parameters
I think we should set model parameters from config map if we are using Kubernetes-based cluster.
A key benefit is that we can share a single point of configuration. For example, share prometheus server endpoint/port with the co-operated prometheus system. share model path with Kepler estimator container.
The `getConfig` will support both setting from configmap mount volume and environment variable.

2. shared paths
I think we can provide model via the shared file system such as NFS.
This will prepare model path (create if not exists) at specific mount point. This is also extensible to other path such as initial dataset.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>