### PR TITLE
refactor prom query

### DIFF
--- a/server/dockerfiles/requirements.txt
+++ b/server/dockerfiles/requirements.txt
@@ -5,3 +5,4 @@ protobuf==3.19.4
 prometheus-client==0.14.1
 pandas==1.4.4
 numpy==1.22.4
+prometheus-api-client==0.5.1

--- a/server/prom/query.py
+++ b/server/prom/query.py
@@ -1,0 +1,91 @@
+import os
+import sys
+
+server_path = os.path.join(os.path.dirname(__file__), '..')
+sys.path.append(server_path)
+
+from prometheus_api_client import PrometheusConnect
+import datetime
+
+import pandas as pd
+from util.config import getConfig
+
+PROM_SERVER = 'http://localhost:9090'
+PROM_SSL_DISABLE = True
+PROM_HEADERS = None
+PROM_QUERY_INTERVAL = 20
+PROM_QUERY_STEP = 3
+
+ROM_SERVER = getConfig('PROM_SERVER', PROM_SERVER)
+PROM_HEADERS = getConfig('PROM_HEADERS', PROM_HEADERS)
+PROM_SSL_DISABLE = getConfig('PROM_SSL_DISABLE', PROM_SSL_DISABLE)
+PROM_QUERY_INTERVAL = getConfig('PROM_QUERY_INTERVAL', PROM_QUERY_INTERVAL)
+
+NODE_STAT_QUERY = 'node_energy_stat'
+POD_STAT_QUERY = 'pod_energy_stat'
+PKG_ENERGY_QUERY = 'node_package_energy_millijoule'
+POD_USAGE_PER_CPU_QUERY = 'pod_cpu_cpu_time_us'
+CPU_FREQUENCY_QUERY = 'node_cpu_scaling_frequency_hertz'
+
+NODE_STAT_QUERY = getConfig('NODE_STAT_QUERY', NODE_STAT_QUERY)
+POD_STAT_QUERY = getConfig('POD_STAT_QUERY', POD_STAT_QUERY)
+PKG_ENERGY_QUERY = getConfig('PKG_ENERGY_QUERY', PKG_ENERGY_QUERY)
+POD_USAGE_PER_CPU_QUERY = getConfig('POD_USAGE_PER_CPU_QUERY', POD_USAGE_PER_CPU_QUERY)
+CPU_FREQUENCY_QUERY = getConfig('CPU_FREQUENCY_QUERY', CPU_FREQUENCY_QUERY)
+
+QUERIES = [NODE_STAT_QUERY, POD_STAT_QUERY, PKG_ENERGY_QUERY, POD_USAGE_PER_CPU_QUERY, CPU_FREQUENCY_QUERY]
+
+def transform_float(val):
+    try: 
+        val = float(val)
+    except:
+        pass
+    return val
+
+class PrometheusClient():
+    def __init__(self):
+        self.prom = PrometheusConnect(url=PROM_SERVER, headers=PROM_HEADERS, disable_ssl=PROM_SSL_DISABLE)
+        self.interval = int(PROM_QUERY_INTERVAL)
+        self.step = int(PROM_QUERY_STEP)
+        self.latest_query_result = dict()
+
+    def query(self):
+        available_metrics = self.prom.all_metrics()
+        end = datetime.datetime.utcnow()
+        start = end - datetime.timedelta(seconds=self.interval)
+        self.latest_query_result = dict()
+        for query_metric in QUERIES:
+            if query_metric not in available_metrics:
+                self.latest_query_result[query_metric] = pd.DataFrame()
+                print("No {} exported".format(query_metric))
+                continue
+            prom_response = self.prom.custom_query_range(query_metric, start, end, self.step, None)
+            items = []
+            for res in prom_response:
+                metric_item = res['metric']
+                for val in res['values']:
+                    item = metric_item.copy()
+                    item['timestamp'] = val[0]
+                    item['value'] = val[1] 
+                    items += [item]
+            df = pd.DataFrame(items) 
+            df.columns = df.columns.str.replace("curr_", "")
+            df.columns = df.columns.str.replace("node_", "")
+            df[query_metric] = df['value']
+            for col in df.columns:
+                df[col] = df[col].transform(transform_float)
+            df.drop(columns=['value'], inplace=True)
+            self.latest_query_result[query_metric] = df
+        
+    def get_data(self, query_metric, features):
+        if len(self.latest_query_result[query_metric]) == 0:
+            return None
+        if features is None:
+            # get all columns
+            return self.latest_query_result[query_metric]
+        try: 
+            data = self.latest_query_result[query_metric][features + [query_metric]]
+        except:
+            data = None
+        return data
+

--- a/server/prom/query_test.py
+++ b/server/prom/query_test.py
@@ -1,0 +1,17 @@
+import os 
+import sys
+
+server_path = os.path.join(os.path.dirname(__file__), '..')
+sys.path.append(server_path)
+
+from train.train_types import FeatureGroups
+from query import PrometheusClient, POD_STAT_QUERY, NODE_STAT_QUERY
+
+if __name__ == "__main__":
+    prom_client = PrometheusClient()
+    prom_client.query()
+    for query_metric in [POD_STAT_QUERY, NODE_STAT_QUERY]: 
+        for fg, features in FeatureGroups.items():
+            data = prom_client.get_data(query_metric, features)
+            print('Query: {} Type: {} Features: {}'.format(query_metric, fg.name, features))
+            print(data if data is not None else None)


### PR DESCRIPTION
This PR refactors the prometheus query approach with the following implementations.

- Instead of manually specify the metric label key on every reference, this refactoring  use pandas from handling query data and use a single point of grouped feature definition in `train/train_types.py`.
- All queries and prometheus parameters are from the configuration.
- Prefix `node_`, `curr_` are removed from the label to share grouped feature definition between pod and node stat.
- Query multiple metrics at the same time because the different trainning pipelines may use different set of query. For example, dynamic power trainning pipeline use pod stat not node stat.

note: there is a dependent getConfig call from PR https://github.com/sustainable-computing-io/kepler-model-server/pull/37.


usage:
```python
# call only every interval in energy_scheduler
prom_client.query()

# call for each training pipieline (used the same cached query); 
# return all available columns if features=None
data = prom_client.get_data(query_metric, features)
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>