### PR TITLE
update train module corresponding to refactored prom query

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import time
+
+util_path = os.path.join(os.path.dirname(__file__), 'util')
+train_path = os.path.join(os.path.dirname(__file__), 'train')
+prom_path = os.path.join(os.path.dirname(__file__), 'prom')
+
+sys.path.append(util_path)
+sys.path.append(train_path)
+sys.path.append(prom_path)
+
+from prom.query import PrometheusClient, PROM_QUERY_INTERVAL
+from train.keras_pipe import KerasFullPipeline
+from util.config import getConfig
+
+SAMPLING_INTERVAL = PROM_QUERY_INTERVAL
+SAMPLING_INTERVAL = getConfig('SAMPLING_INTERVAL', SAMPLING_INTERVAL)
+SAMPLING_INTERVAL = int(SAMPLING_INTERVAL)
+
+pipelines = [KerasFullPipeline()]
+
+if __name__ == '__main__':
+    prom_client = PrometheusClient()
+    while True:
+        prom_client.query()
+        for pipeline in pipelines:
+            pipeline.train(prom_client)
+        time.sleep(SAMPLING_INTERVAL)

--- a/server/train/__init__.py
+++ b/server/train/__init__.py
@@ -1,1 +1,0 @@
-from train.kepler_model_trainer import generate_core_regression_model, train_model_given_data_and_type

--- a/server/train/keras_pipe_test.py
+++ b/server/train/keras_pipe_test.py
@@ -1,0 +1,36 @@
+from random import random
+from keras_pipe import KerasFullPipeline
+from prom.query import NODE_STAT_QUERY
+
+if __name__ == '__main__':
+    from prom.query import PrometheusClient
+    from train_types import WORKLOAD_FEATURES, SYSTEM_FEATURES, CATEGORICAL_LABEL_TO_VOCAB, NODE_STAT_POWER_LABEL
+    import pandas as pd
+    import numpy as np
+    item = dict()
+
+    for f in WORKLOAD_FEATURES:
+        item[f] = random()
+    for f in SYSTEM_FEATURES:
+        if f in CATEGORICAL_LABEL_TO_VOCAB:
+            item[f] = CATEGORICAL_LABEL_TO_VOCAB[f][0]
+        else:
+            item[f] = random()
+    for l in NODE_STAT_POWER_LABEL:
+        item[l] = random()*1000
+
+    data_items = [item]
+    node_stat_data = pd.DataFrame(data_items)
+    print(node_stat_data.head())
+    for f in WORKLOAD_FEATURES:
+        node_stat_data[f] = node_stat_data[f].astype(np.float32)
+    for f in SYSTEM_FEATURES:
+        if f not in CATEGORICAL_LABEL_TO_VOCAB:
+            node_stat_data[f] = node_stat_data[f].astype(np.float32)
+
+    node_stat_data = pd.concat([node_stat_data]*10, ignore_index=True)
+    prom_client = PrometheusClient()
+    prom_client.latest_query_result[NODE_STAT_QUERY] = node_stat_data
+    pipeline = KerasFullPipeline()
+    pipeline.train(prom_client)
+    pipeline.predict(node_stat_data[pipeline.features].values)

--- a/server/train/pipeline.py
+++ b/server/train/pipeline.py
@@ -1,19 +1,18 @@
+import os
+import sys
+
+server_path = os.path.join(os.path.dirname(__file__), '..')
+sys.path.append(server_path)
+
 from abc import ABCMeta, abstractmethod
 from train_types import FeatureGroup, get_feature_group
-
-import os
 import json
 
-TRAIN_MODEL_PATH_ENV = 'TRAIN_MODEL_PATH'
+from util.config import getConfig, getPath
+
 METADATA_FILENAME = 'metadata.json'
 
-if TRAIN_MODEL_PATH_ENV not in os.environ:
-    model_path = os.path.join(os.path.dirname(__file__), 'local')
-else:
-    model_path = os.getenv(TRAIN_MODEL_PATH_ENV)
-
-if not os.path.exists(model_path):
-    os.mkdir(model_path)
+model_path =  getPath(getConfig('MODEL_PATH', 'models'))
 
 for g in FeatureGroup:
     group_path = os.path.join(model_path, g.name)
@@ -45,9 +44,8 @@ class TrainPipeline(metaclass=ABCMeta):
         with open(metadata_file, "w") as f:
             json.dump(item, f)
         
-
     @abstractmethod
-    def train(self, pod_stat_data, node_stat_data, freq_data, pkg_data):
+    def train(self, prom_client):
         return NotImplemented
 
     def get_model_specific_metadata(self):

--- a/server/train/train_types.py
+++ b/server/train/train_types.py
@@ -13,10 +13,10 @@ import random
 
 SYSTEM_FEATURES = ["cpu_architecture"]
 
-COUNTER_FEAUTRES = ["curr_cache_miss", "curr_cpu_cycles", "curr_cpu_instr"]
-CGROUP_FEATURES = ["curr_cgroupfs_cpu_usage_us", "curr_cgroupfs_memory_usage_bytes", "curr_cgroupfs_system_cpu_usage_us", "curr_cgroupfs_user_cpu_usage_us"]
-IO_FEATURES = ["curr_bytes_read", "curr_bytes_writes"]
-BPF_FEATURES = ["curr_cpu_time"]
+COUNTER_FEAUTRES = ["cache_miss", "cpu_cycles", "cpu_instr"]
+CGROUP_FEATURES = ["cgroupfs_cpu_usage_us", "cgroupfs_memory_usage_bytes", "cgroupfs_system_cpu_usage_us", "cgroupfs_user_cpu_usage_us"]
+IO_FEATURES = ["bytes_read", "bytes_writes"]
+BPF_FEATURES = ["cpu_time"]
 KUBELET_FEATURES =['container_cpu_usage_seconds_total', 'container_memory_working_set_bytes']
 WORKLOAD_FEATURES = COUNTER_FEAUTRES + CGROUP_FEATURES + IO_FEATURES + BPF_FEATURES + KUBELET_FEATURES
 
@@ -24,7 +24,7 @@ CATEGORICAL_LABEL_TO_VOCAB = {
                     "cpu_architecture": ["Sandy Bridge", "Ivy Bridge", "Haswell", "Broadwell", "Sky Lake", "Cascade Lake", "Coffee Lake", "Alder Lake"] 
                     }
 
-NODE_STAT_POWER_LABEL = ["node_curr_energy_in_pkg_joule", "node_curr_energy_in_core_joule", "node_curr_energy_in_dram_joule", "node_curr_energy_in_uncore_joule", "node_curr_energy_in_gpu_joule", "node_curr_energy_in_other_joule"]
+NODE_STAT_POWER_LABEL = ["energy_in_pkg_joule", "energy_in_core_joule", "energy_in_dram_joule", "energy_in_uncore_joule", "energy_in_gpu_joule", "energy_in_other_joule"]
 
 class FeatureGroup(enum.Enum):
    Full = 1


### PR DESCRIPTION
This PR updates example `keras_pipe.py` to use non-prefix features corresponding to new prometheus query approach in this PR https://github.com/sustainable-computing-io/kepler-model-server/pull/38.

Also, update configuration and model path preparation using `getConfig`, `getPath` function from this PR https://github.com/sustainable-computing-io/kepler-model-server/pull/37.

To use new refactored trainning pipeline, check `server/main.py`

```python
 import os
 import sys
 import time

 util_path = os.path.join(os.path.dirname(__file__), 'util')
 train_path = os.path.join(os.path.dirname(__file__), 'train')
 prom_path = os.path.join(os.path.dirname(__file__), 'prom')

 sys.path.append(util_path)
 sys.path.append(train_path)
 sys.path.append(prom_path)

 from prom.query import PrometheusClient, PROM_QUERY_INTERVAL
 from train.keras_pipe import KerasFullPipeline
 from util.config import getConfig

 SAMPLING_INTERVAL = PROM_QUERY_INTERVAL
 SAMPLING_INTERVAL = getConfig('SAMPLING_INTERVAL', SAMPLING_INTERVAL)
 SAMPLING_INTERVAL = int(SAMPLING_INTERVAL)

# add new pipeline here
 pipelines = [KerasFullPipeline()]

 if __name__ == '__main__':
     prom_client = PrometheusClient()
     while True:
         prom_client.query()
         for pipeline in pipelines:
             pipeline.train(prom_client)
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>