### PR TITLE
add description of power model and api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,123 @@
 # Kepler Model Server
-**Online ML model Server for Kepler (Developer Readme)**
 
-**Different ways to run the model training on the server:**
+### Getting Power Models
+```
+/model
+POST
+```
 
-**Testing the models using simple pre-written test cases for model training error checking:**
+Parameters
+|key|value|description
+|---|---|---|
+|metrics|list of string|list of available input features (measured metrics)*
+|output_type|either of the following values: *AbsPower*, *AbsModelWeight*, *AbsComponentPower*, *AbsComponentModelWeight*, *DynPower*,  *DynModelWeight*, *DynComponentPower*, *DynComponentModelWeight*|the requested model kinds and forms \**
+model_name (optional)|string|fixed pipeline name* (auto-select the model with lowest error if not specified)
+filters (optional)|string|expression in the form *attribute1*:*threshold1*; *attribute2*:*threshold2*
 
-From the project folder, run 'python -m tests.kepler_regression_model_tests' to create, train, and save Dram and Core Models or retrain and save pre-existing Dram and Core Models.
+\* refer to pipeline and features definitions in [here](./doc/train_pipeline.md)
 
-**Running the model server with Kepler metrics (Online Learning)**
+\** refer to power model choices described [here](#power-models)
 
-Set up and run [Kepler](https://github.com/sustainable-computing-io/kepler). [Kepler](https://github.com/sustainable-computing-io/kepler) will now export Prometheus metrics. Run the model server's energy_scheduler.py module to pull [Kepler's](https://github.com/sustainable-computing-io/kepler) Prometheus metrics. These metrics will be used to automatically train a new model or retrain a model. Currently only the core_model Linear Regression Model is included.  
+#### Available model training pipelines
+##### AbsPower
+|Pipeline Name|Learning Approach|Features|Online|
+|---|---|---|---|
+|KerasFullPipeline|Single-layer Linear Regression with Adam optimizer (learning_rate=0.5), loss='mae'|Full|O
 
-**Viewing the exported model weights for a given model:**
+##### AbsModelWeight (WIP)
 
-**Checking the model weights for a given model using Flask Routes:**
+##### AbsComponentPower (core,dram)
+|Pipeline Name|Learning Approach|Features|Online|
+|---|---|---|---|
+|KerasCompFullPipeline|Single-layer Linear Regression with Adam optimizer (learning_rate=0.5), loss='mae'|Full|O
 
-To test the routes that use the model, call 'python server.py'. Available routes include '/models/<model_type>' and '/model-weights/<model_type>'. '/models/<model_type>' returns the saved model as a zip that needs to be extracted before being used. '/model-weights/<model_type>' returns the weights of a given model. Acceptable values for <model_type> are 'core_model' and 'dram_model'.
+##### AbsComponentModelWeight (core, dram)
+|Pipeline Name|Learning Approach|Features|Online|
+|---|---|---|---|
+|KerasCompWeightFullPipeline|Single-layer Linear Regression with Adam optimizer (learning_rate=0.5), loss='mae'|Full|O
 
-**Checking the model weights using Prometheus:**
+##### DynPower 
+|Pipeline Name|Learning Approach|Features|Online|
+|---|---|---|---|
+ScikitMixed|Gradient Boosting Regressor|Full, Cgroup|x|
 
-    1. Call python server.py. Navigate to '/metrics' route to view all model weights for all available models. This is for quick testing purposes only
+##### DynModelWeight (WIP)
 
-    OR
+##### DynComponentPower (WIP)
 
-    2. Call 'docker-compose up' at project root. Navigate to '/metrics' route to view all model weights for all available models. 
+##### DynComponentModelWeight (WIP)
 
-**Checking the model weights using OpenTelemetry (WIP):**
+Example outputs:
 
-Call 'docker-compose up' at project root. Prometheus metrics will be scraped and converted to OpenTelemetry Metrics. These metrics will be shown in the log and will be exported to a otlp endpoint. A Honeycomb.io dataset is currently in the works.
+*Weights*
+```json
+{"All_Weights": 
+  {
+  "Bias_Weight": 1.0, 
+  "Categorical_Variables": {"cpu_architecture": {"Sky Lake": {"weight": 1.0}}}, 
+  "Numerical_Variables": {"cpu_cycles": {"mean": 0, "variance": 1.0, "weight": 1.0}}
+  }
+}
+```
+*Archived model*
+```bash
+├── AbsComponentPower
+│   ├── KerasCompFullPipeline.json
+│   ├── core
+│   │   ├── assets
+│   │   ├── keras_metadata.pb
+│   │   ├── saved_model.pb
+│   │   └── variables
+│   │       ├── variables.data-00000-of-00001
+│   │       └── variables.index
+│   ├── core_transform.pkl
+│   ├── dram
+│   │   ├── assets
+│   │   ├── keras_metadata.pb
+│   │   ├── saved_model.pb
+│   │   └── variables
+│   │       ├── variables.data-00000-of-00001
+│   │       └── variables.index
+│   ├── dram_transform.pkl
+│   └── metadata.json
+└── DynPower
+    ├── metadata.json
+    ├── model.sav
+    └── scaler.pkl
+```
 
+
+### Posting Model Weights [WIP]
+```
+/metrics
+GET
+```
+
+## Power Models
+
+There are two broad kinds of power models provided by the model server: absolute power model (Abs) and dynamic power model (Dyn). 
+
+**Absolute Power Model (Abs):** power model trained by measured power (including the idle power)
+
+**Dynamic Power Model (Dyn):** power model trained by delta power (measured power with workload - idle power)
+
+The absolute power model is supposed to use for estimating node-level power while the dynamic power model is supposed to use for estimating pod-level power. 
+
+Note that, the node-level power would be applied in the case that the measured power or low-level highly-dependent features (such as temperature sensors) are not available such as in virtualized systems, non-instrumented systems.
+
+For each kind, the model can be in four following forms.
+
+Key Name| Model Form|Output per single input|
+---|---|---|
+Power|achived model|single power value|
+ModelWeight|weights for normalized linear regression model|single power value|
+ComponentPower|achived model|multiple power values for each components (e.g., core, dram)
+ComponentWeight|weights for normalized linear regression model|multiple power values for each components (e.g., core, dram)|
+
+The achived model allows more choices of learning approachs to estimate the power which can expect higher accuracy and overfitting resolutions while weights of linear regression model provides simplicity and lightweight. **Accordingly, the achived model is suitable for the systems that run intensive and non-deterministic workloads which require accurate prediction while the weights of linear regression is suitable for the systems which run for deterministic workloads in general.**
+
+Single power value can blend the inter-dependency between each power-consuming components into the model while multiple power values for each components can give more insight analysis with a precision tradeoff. **Accordingly, if we want insight analysis and have enough component-level training data to build the component model with acceptable accuracy, the multiple power values are preferable. Otherwise, single power value should be a common choice**
+
+
+### Contributing
+Please check the roadmap and guidelines to join us [here](./contributing.md).

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Roadmap:
+- [ ] Build default pipelines for all kinds and forms of models and input types
+- [ ] Increase accessibility to the model
+  - [ ] Enable post-based approach to provide model weights via prometheus
+        Checking the model weights using OpenTelemetry
+        Call 'docker-compose up' at project root. Prometheus metrics will be scraped and converted to OpenTelemetry Metrics. These metrics will be shown in the log and will be exported to a otlp endpoint. A Honeycomb.io dataset is currently in the works.
+  - [ ] Plugin Cloud object storage
+
+The main source codes are in [server directory](./server/).
+```bash
+server
+├── model_server.py # program endpoint for serving API routes
+├── online_trainer.py # program endpoint for periodic online training
+├── prom # prometheus-related functions
+├── train # model definition and online training pipelines
+└── util # general utility functions 
+``` 
+
+#### Implementing Pipelines
+Check details in [here](./doc/train_pipeline.md)
+
+#### Implementing test case
+Check the [tests directory](./tests/)
+```bash
+├── tests
+│   ├── test_models # initial model for testing
+│   ├── download # output path when calling API endpoints
+│   └── query_data # sample query data for testing the pipelines
+``` 
+


### PR DESCRIPTION
This PR updates README.md with API endpoint descriptions.
It includes the description about each output model type and recommendation of use, template for available list of model training pipelines. 

The previous description is updated and moved to contributing page for developers.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>