### PR TITLE
update deployment manifests and workflows

### DIFF
--- a/.github/workflows/cluster_deploy.yml
+++ b/.github/workflows/cluster_deploy.yml
@@ -1,0 +1,53 @@
+name: Create Kind Cluster with Kepler Model Server
+
+on:
+  workflow_call:
+    inputs:
+      storage:
+        required: false
+        type: string
+        default: local
+      online_trainer:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  cluster_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Create Kind Cluster
+      uses: helm/kind-action@v1.3.0
+
+    - name: Checkout prometheus if online_trainer enabled
+      if: ${{ inputs.online_trainer }}
+      uses: actions/checkout@v3
+      with:
+        repository: prometheus-operator/kube-prometheus
+
+    - name: Deploy prometheus operator if online_trainer enabled
+      if: ${{ inputs.online_trainer }}
+      run: |
+        kubectl create -f manifests/setup
+        until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
+        kubectl create -f manifests/
+
+    - uses: actions/checkout@v3
+
+    - name: Build docker image and tag target registry
+      run: |
+        docker build -t kind-registry:5000/kepler_model_server:latest server/ -f server/dockerfiles/Dockerfile
+        docker tag kind-registry:5000/kepler_model_server:latest quay.io/sustainable_computing_io/kepler_model_server:latest
+
+    - name: Create monitoring namespace if no online trainer pre-creation
+      if: ${{ !inputs.online_trainer }}
+      run: kubectl create namespace monitoring
+
+
+    - name: Deploy Model Server
+      run: kubectl create -f manifests/${{ inputs.storage }}/deployment.yaml
+    
+    - name: Patch online trainer if enabled
+      if: ${{ inputs.online_trainer }}
+      run: kubectl patch deployment kepler-model-server --patch-file manifests/${{ inputs.storage }}/trainer-patch.yaml -n monitoring

--- a/.github/workflows/cluster_deploy.yml
+++ b/.github/workflows/cluster_deploy.yml
@@ -14,7 +14,11 @@ on:
       load_initial_models:
         required: false
         type: boolean
-        default: false   
+        default: false
+      namespace:
+        required: false
+        type: string
+        default: monitoring
 
 jobs:
   cluster_deploy:
@@ -50,13 +54,21 @@ jobs:
         docker tag kind-registry:5000/kepler_model_server:latest quay.io/sustainable_computing_io/kepler_model_server:latest
 
     - name: Create monitoring namespace if no online trainer pre-creation
-      if: ${{ !inputs.online_trainer }}
-      run: kubectl create namespace monitoring
-
+      if: ${{ (!inputs.online_trainer) || (inputs.namespace != 'monitoring') }}
+      run: kubectl create namespace ${{ inputs.namespace }}
 
     - name: Deploy Model Server
       run: kubectl create -f manifests/${{ inputs.storage }}/deployment.yaml
     
     - name: Patch online trainer if enabled
       if: ${{ inputs.online_trainer }}
-      run: kubectl patch deployment kepler-model-server --patch-file manifests/${{ inputs.storage }}/trainer-patch.yaml -n monitoring
+      run: kubectl patch deployment kepler-model-server --patch-file manifests/${{ inputs.storage }}/trainer-patch.yaml -n ${{ inputs.namespace }}
+
+    - name: Describe deployment
+      run: kubectl describe deployment kepler-model-server -n ${{ inputs.namespace }}
+
+    - name: Get pod
+      run: kubectl get pod --selector app.kubernetes.io/name=kepler-model-server -n ${{ inputs.namespace }} -o yaml
+
+    - name: Check deployment availablility
+      run: kubectl wait deployment kepler-model-server -n ${{ inputs.namespace }} --for condition=Available=True --timeout=120s

--- a/.github/workflows/cluster_deploy.yml
+++ b/.github/workflows/cluster_deploy.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         default: monitoring
+      image-build:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   cluster_deploy:
@@ -49,9 +53,22 @@ jobs:
         cp -r tests/test_models server/models
 
     - name: Build docker image and tag target registry
+      if: ${{ inputs.image-build }}
       run: |
         docker build -t kind-registry:5000/kepler_model_server:latest server/ -f server/dockerfiles/Dockerfile
         docker tag kind-registry:5000/kepler_model_server:latest quay.io/sustainable_computing_io/kepler_model_server:latest
+
+    - name: Login to Quay
+      if: ${{ !inputs.image-build }}
+      uses: docker/login-action@v1
+      with:
+          registry: quay.io/sustainable_computing_io
+          username: ${{ secrets.BOT_NAME }}
+          password: ${{ secrets.BOT_TOKEN }}      
+
+    - name: Pull image
+      if: ${{ !inputs.image-build }}
+      run: docker pull quay.io/sustainable_computing_io/kepler_model_server:latest
 
     - name: Create monitoring namespace if no online trainer pre-creation
       if: ${{ (!inputs.online_trainer) || (inputs.namespace != 'monitoring') }}

--- a/.github/workflows/cluster_deploy.yml
+++ b/.github/workflows/cluster_deploy.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: boolean
         default: false
+      load_initial_models:
+        required: false
+        type: boolean
+        default: false   
 
 jobs:
   cluster_deploy:
@@ -34,6 +38,11 @@ jobs:
         kubectl create -f manifests/
 
     - uses: actions/checkout@v3
+
+    - name: Copy inital model to server path
+      if: ${{ inputs.load_initial_models }}
+      run: |
+        cp -r tests/test_models server/models
 
     - name: Build docker image and tag target registry
       run: |

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+
+jobs:
+  server_only_with_local:
+    uses: ./.github/workflows/cluster_deploy.yml
+  server_only_with_host_local:
+    uses: ./.github/workflows/cluster_deploy.yml
+    with:
+      storage: host-local
+  with_online_trainer:
+    uses: ./.github/workflows/cluster_deploy.yml
+    with:
+      online_trainer: true

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -4,6 +4,10 @@ on:
 jobs:
   server_only_with_local:
     uses: ./.github/workflows/cluster_deploy.yml
+  local_server_with_inital_models:
+    uses: ./.github/workflows/cluster_deploy.yml
+    with:
+      load_initial_models: true
   server_only_with_host_local:
     uses: ./.github/workflows/cluster_deploy.yml
     with:

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -8,10 +8,6 @@ jobs:
     uses: ./.github/workflows/cluster_deploy.yml
     with:
       load_initial_models: true
-  server_only_with_host_local:
-    uses: ./.github/workflows/cluster_deploy.yml
-    with:
-      storage: host-local
   with_online_trainer:
     uses: ./.github/workflows/cluster_deploy.yml
     with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Makefile and Push
+name: Build and push image
 
 on:
   push:
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       
-    - name: Install dependencies
-      run: podman build -t quay.io/sustainable_computing_io/kepler_model_server:latest server/ -f server/dockerfiles/Dockerfile
+    - name: Build image
+      run: docker build -t quay.io/sustainable_computing_io/kepler_model_server:latest server/ -f server/dockerfiles/Dockerfile
       
     - name: Login to Quay
       uses: docker/login-action@v1
@@ -22,5 +22,5 @@ jobs:
           username: ${{ secrets.BOT_NAME }}
           password: ${{ secrets.BOT_TOKEN }}      
 
-    - name: push to quay
-      run: podman push quay.io/sustainable_computing_io/kepler_model_server:latest
+    - name: Push to quay
+      run: docker push quay.io/sustainable_computing_io/kepler_model_server:latest

--- a/manifests/host-local/deployment.yaml
+++ b/manifests/host-local/deployment.yaml
@@ -72,6 +72,7 @@ spec:
       containers:
       - name: server-api
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8100
         volumeMounts:

--- a/manifests/host-local/deployment.yaml
+++ b/manifests/host-local/deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler-model-server-cfm
+  namespace: monitoring
+data:
+  MODEL_PATH: models
+  PROM_SERVER: 'http://prometheus-k8s.monitoring.svc.cluster.local:9090'
+  PROM_QUERY_INTERVAL: '20'
+  PROM_QUERY_STEP: '3'
+  PROM_HEADERS: ''
+  PROM_SSL_DISABLE: 'true'
+  MNT_PATH: /mnt
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kepler-model-server-pv
+  labels:
+    type: local
+    app.kubernetes.io/component: kepler-model-server-pv
+    app.kubernetes.io/name: kepler-model-server-pv
+spec:
+  storageClassName: default
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: "/mnt/data"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kepler-model-server-pvc
+  namespace: monitoring
+spec:
+  storageClassName: default
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kepler-model-server
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: model-server
+    app.kubernetes.io/name: kepler-model-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: model-server
+      app.kubernetes.io/name: kepler-model-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: model-server
+        app.kubernetes.io/name: kepler-model-server
+    spec:
+      volumes:
+      - name: mnt
+        persistentVolumeClaim:
+          claimName: kepler-model-server-pvc
+      - name: cfm
+        configMap:
+          name: kepler-model-server-cfm
+      containers:
+      - name: server-api
+        image: quay.io/sustainable_computing_io/kepler_model_server:latest
+        ports:
+        - containerPort: 8100
+        volumeMounts:
+          - name: mnt
+            mountPath: /mnt
+          - name: cfm
+            mountPath: /etc/config
+            readOnly: true
+        command: ["python3.8",  "model_server.py"]
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: kepler-model-server
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/component: model-server
+    app.kubernetes.io/name: kepler-model-server
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/component: model-server
+    app.kubernetes.io/name: kepler-model-server
+  ports:
+  - name: http
+    port: 8100
+    targetPort: http

--- a/manifests/host-local/trainer-patch.yaml
+++ b/manifests/host-local/trainer-patch.yaml
@@ -1,0 +1,14 @@
+spec:
+  template:
+    spec:
+      containers:
+      - name: online-trainer
+        image: quay.io/sustainable_computing_io/kepler_model_server:latest
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - name: mnt
+            mountPath: /mnt
+          - name: cfm
+            mountPath: /etc/config
+            readOnly: true
+        command: ["python3.8",  "online_trainer.py"]

--- a/manifests/local/deployment.yaml
+++ b/manifests/local/deployment.yaml
@@ -1,32 +1,15 @@
 apiVersion: v1
-kind: PersistentVolume
+kind: ConfigMap
 metadata:
-  name: kepler-model-server-pv
-  labels:
-    type: local
-    app.kubernetes.io/component: kepler-model-server-pv
-    app.kubernetes.io/name: kepler-model-server-pv
-spec:
-  storageClassName: default
-  capacity:
-    storage: 5Gi
-  accessModes:
-    - ReadWriteOnce
-  hostPath:
-    path: "/mnt/data"
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: kepler-model-server-pvc
+  name: kepler-model-server-cfm
   namespace: monitoring
-spec:
-  storageClassName: default
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5Gi
+data:
+  MODEL_PATH: models
+  PROM_SERVER: 'http://prometheus-k8s.monitoring.svc.cluster.local:9090'
+  PROM_QUERY_INTERVAL: '20'
+  PROM_QUERY_STEP: '3'
+  PROM_HEADERS: ''
+  PROM_SSL_DISABLE: 'true'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,26 +32,22 @@ spec:
         app.kubernetes.io/name: kepler-model-server
     spec:
       volumes:
-      - name: models
+      - name: mnt
         persistentVolumeClaim:
           claimName: kepler-model-server-pvc
+      - name: cfm
+        configMap:
+          name: kepler-model-server-cfm
       containers:
-      - name: kepler-model-server
+      - name: server-api
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
         ports:
         - containerPort: 8100
         volumeMounts:
-          - name: models
-            mountPath: /models
-      - name: kepler-model-trainer
-        image: quay.io/sustainable_computing_io/kepler_model_server:latest
-        command: ["python3.8",  "energy_scheduler.py"]
-        env:
-        - name: PROMETHEUS_ENDPOINT
-          value: "http://prometheus-k8s:9090/api/v1/query"
-        volumeMounts:
-          - name: models
-            mountPath: /models
+          - name: cfm
+            mountPath: /etc/config
+            readOnly: true
+        command: ["python3.8",  "model_server.py"]
 ---
 kind: Service
 apiVersion: v1

--- a/manifests/local/deployment.yaml
+++ b/manifests/local/deployment.yaml
@@ -32,15 +32,13 @@ spec:
         app.kubernetes.io/name: kepler-model-server
     spec:
       volumes:
-      - name: mnt
-        persistentVolumeClaim:
-          claimName: kepler-model-server-pvc
       - name: cfm
         configMap:
           name: kepler-model-server-cfm
       containers:
       - name: server-api
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8100
         volumeMounts:

--- a/manifests/local/trainer-patch.yaml
+++ b/manifests/local/trainer-patch.yaml
@@ -4,6 +4,7 @@ spec:
       containers:
       - name: online-trainer
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
+        imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: cfm
             mountPath: /etc/config

--- a/manifests/local/trainer-patch.yaml
+++ b/manifests/local/trainer-patch.yaml
@@ -1,0 +1,11 @@
+spec:
+  template:
+    spec:
+      containers:
+      - name: online-trainer
+        image: quay.io/sustainable_computing_io/kepler_model_server:latest
+        volumeMounts:
+          - name: cfm
+            mountPath: /etc/config
+            readOnly: true
+        command: ["python3.8",  "online_trainer.py"]

--- a/server/online_trainer.py
+++ b/server/online_trainer.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import time
+
+util_path = os.path.join(os.path.dirname(__file__), 'util')
+train_path = os.path.join(os.path.dirname(__file__), 'train')
+prom_path = os.path.join(os.path.dirname(__file__), 'prom')
+
+sys.path.append(util_path)
+sys.path.append(train_path)
+sys.path.append(prom_path)
+
+from prom.query import PrometheusClient, PROM_QUERY_INTERVAL
+from util.config import getConfig
+
+SAMPLING_INTERVAL = PROM_QUERY_INTERVAL
+SAMPLING_INTERVAL = getConfig('SAMPLING_INTERVAL', SAMPLING_INTERVAL)
+SAMPLING_INTERVAL = int(SAMPLING_INTERVAL)
+
+pipeline_names = ['KerasFullPipeline']
+grouped_pipelines = dict()
+
+for pipeline_name in pipeline_names:
+    pipeline_path = os.path.join(os.path.dirname(__file__), 'train/pipelines/{}'.format(pipeline_name))
+    sys.path.append(pipeline_path)
+    import importlib
+    pipeline_module = importlib.import_module('train.pipelines.{}.pipe'.format(pipeline_name))
+    pipeline = getattr(pipeline_module, pipeline_name)()
+    output_type = pipeline.output_type.name
+    if output_type not in grouped_pipelines:
+        grouped_pipelines[output_type] = []
+    grouped_pipelines[output_type] += [pipeline]
+
+def run_train(pipeline, prom_client):
+    pipeline.train(prom_client)
+
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import wait
+
+if __name__ == '__main__':
+    prom_client = PrometheusClient()
+    while True:
+        prom_client.query()
+
+        # start the thread pool
+        with ThreadPoolExecutor(2) as executor:
+            futures = []
+            for output_type, pipelines in grouped_pipelines.items():
+                for pipeline in pipelines:
+                    future = executor.submit(run_train, pipeline, prom_client)
+                    futures += [future]
+            print('Waiting for tasks to complete...')
+            wait(futures)
+            print('All trained!')
+        time.sleep(SAMPLING_INTERVAL)

--- a/server/prom/query.py
+++ b/server/prom/query.py
@@ -72,18 +72,11 @@ class PrometheusClient():
             df = pd.DataFrame(items) 
             df.columns = df.columns.str.replace("curr_", "")
             df.columns = df.columns.str.replace("node_", "")
-<<<<<<< HEAD
             if len(df) > 0:
                 df[query_metric] = df['value']
                 for col in df.columns:
                     df[col] = df[col].transform(transform_float)
                 df.drop(columns=['value'], inplace=True)
-=======
-            df[query_metric] = df['value']
-            for col in df.columns:
-                df[col] = df[col].transform(transform_float)
-            df.drop(columns=['value'], inplace=True)
->>>>>>> 2f0c7be (refactor prom query)
             self.latest_query_result[query_metric] = df
         
     def get_data(self, query_metric, features):

--- a/server/prom/query.py
+++ b/server/prom/query.py
@@ -72,11 +72,18 @@ class PrometheusClient():
             df = pd.DataFrame(items) 
             df.columns = df.columns.str.replace("curr_", "")
             df.columns = df.columns.str.replace("node_", "")
+<<<<<<< HEAD
             if len(df) > 0:
                 df[query_metric] = df['value']
                 for col in df.columns:
                     df[col] = df[col].transform(transform_float)
                 df.drop(columns=['value'], inplace=True)
+=======
+            df[query_metric] = df['value']
+            for col in df.columns:
+                df[col] = df[col].transform(transform_float)
+            df.drop(columns=['value'], inplace=True)
+>>>>>>> 2f0c7be (refactor prom query)
             self.latest_query_result[query_metric] = df
         
     def get_data(self, query_metric, features):


### PR DESCRIPTION
This PR updates the deployment manifests grouping by the storage choice (currently covers only host-local and (pod)local).

In addition, the PR includes the following CI workflows.
- reusable cluster_deploy: deploy Kind Cluster with kepler-model-server (and prometheus if online-trainer is enabled)
- server_only_with_local: call cluster_deploy to deploy kepler-model-server without online_trainer patch with pod local
- server_only_with_host-local:  similar to server_only_with_local but with hostpath PV and corresponding PVC and MNT_PATH config
- with_online_trainer: with prometheus and with side-car online trainer

Signed-off-by: Sunyanan Choochotkaew [sunyanan.choochotkaew1@ibm.com](mailto:sunyanan.choochotkaew1@ibm.com)