### PR TITLE
add loading initial models by config

### DIFF
--- a/.github/workflows/cluster_deploy.yml
+++ b/.github/workflows/cluster_deploy.yml
@@ -11,10 +11,6 @@ on:
         required: false
         type: boolean
         default: false
-      load_initial_models:
-        required: false
-        type: boolean
-        default: false
       namespace:
         required: false
         type: string
@@ -47,11 +43,6 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Copy inital model to server path
-      if: ${{ inputs.load_initial_models }}
-      run: |
-        cp -r tests/test_models server/models
-
     - name: Build docker image and tag target registry
       if: ${{ inputs.image-build }}
       run: |
@@ -75,7 +66,7 @@ jobs:
       run: kubectl create namespace ${{ inputs.namespace }}
 
     - name: Deploy Model Server
-      run: kubectl create -f manifests/${{ inputs.storage }}/deployment.yaml
+      run: kubectl apply -f manifests/${{ inputs.storage }}/deployment.yaml
     
     - name: Patch online trainer if enabled
       if: ${{ inputs.online_trainer }}

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -4,10 +4,6 @@ on:
 jobs:
   server_only_with_local:
     uses: ./.github/workflows/cluster_deploy.yml
-  local_server_with_inital_models:
-    uses: ./.github/workflows/cluster_deploy.yml
-    with:
-      load_initial_models: true
   with_online_trainer:
     uses: ./.github/workflows/cluster_deploy.yml
     with:

--- a/manifests/host-local/deployment.yaml
+++ b/manifests/host-local/deployment.yaml
@@ -11,6 +11,11 @@ data:
   PROM_HEADERS: ''
   PROM_SSL_DISABLE: 'true'
   MNT_PATH: /mnt
+  INITIAL_MODELS_LOC: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models
+  INITIAL_MODEL_NAMES: |
+    AbsComponentModelWeight=KerasCompWeightFullPipeline
+    AbsComponentPower=KerasCompFullPipeline
+    DynComponentPower=ScikitMixed
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/manifests/local/deployment.yaml
+++ b/manifests/local/deployment.yaml
@@ -10,6 +10,11 @@ data:
   PROM_QUERY_STEP: '3'
   PROM_HEADERS: ''
   PROM_SSL_DISABLE: 'true'
+  INITIAL_MODELS_LOC: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models
+  INITIAL_MODEL_NAMES: |
+    AbsComponentModelWeight=KerasCompWeightFullPipeline
+    AbsComponentPower=KerasCompFullPipeline
+    DynComponentPower=ScikitMixed
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -39,6 +44,9 @@ spec:
       - name: server-api
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
         imagePullPolicy: IfNotPresent
+        env:
+        - name: INITIAL_MODELS_LOC
+          value: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models
         ports:
         - containerPort: 8100
         volumeMounts:

--- a/server/util/loader.py
+++ b/server/util/loader.py
@@ -1,6 +1,9 @@
 import os
 import json
 
+import requests
+import codecs
+
 FILTER_ITEM_DELIMIT = ';'
 VALUE_DELIMIT = ':'
 ARRAY_DELIMIT = ','
@@ -58,3 +61,17 @@ def get_archived_file(group_path, model_name):
 def get_model_weight(group_path, model_name, model_file):
     save_path = get_save_path(group_path, model_name)
     return load_json(save_path, model_file)
+
+def download_and_save(url, filepath):
+    try:
+        response = requests.get(url)
+    except Exception as e:
+        print("Failed to load {} to {}: {}:".format(url, filepath, e))
+        return None
+    if response.status_code != 200:
+        print("Failed to load {} to {}: {}:".format(url, filepath, response.status_code))
+        return None
+    with codecs.open(filepath, 'wb') as f:
+        f.write(response.content)
+    print("Successfully load {} to {}".format(url, filepath))
+    return filepath


### PR DESCRIPTION
This PR implements a function to initially download the offline trained model by URL set in the configmap as below.

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kepler-model-server-cfm
  namespace: monitoring
data:
  ...
  INITIAL_MODELS_LOC: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models
  INITIAL_MODEL_NAMES: |
    AbsComponentModelWeight=KerasCompWeightFullPipeline
    AbsComponentPower=KerasCompFullPipeline
    DynComponentPower=ScikitMixed
```

Also, `load_initial_models` input in the workflows/cluster_deploy.yml is no need anymore.


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>