### PR TITLE
change imagePullPolicy to Always and remove deprecated env set

### DIFF
--- a/manifests/host-local/deployment.yaml
+++ b/manifests/host-local/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       containers:
       - name: server-api
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 8100
         volumeMounts:

--- a/manifests/local/deployment.yaml
+++ b/manifests/local/deployment.yaml
@@ -43,10 +43,7 @@ spec:
       containers:
       - name: server-api
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: INITIAL_MODELS_LOC
-          value: https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-server/main/tests/test_models
+        imagePullPolicy: Always
         ports:
         - containerPort: 8100
         volumeMounts:


### PR DESCRIPTION
This PR changes imagePullPolicy of kepler-model-server deployment to Always to keep the image up-to-date in integration test. 

Additionally, it removes deprecated INITIAL_MODELS_LOC environment (now it is defined by configmap).

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>