### PR TITLE
Include scikit learn in kepler-model-server-base

### DIFF
--- a/server/dockerfiles/requirements.txt
+++ b/server/dockerfiles/requirements.txt
@@ -7,3 +7,4 @@ numpy==1.22.4
 prometheus-client==0.14.1
 prometheus-api-client==0.5.1
 xgboost==1.6.2
+scikit-learn==1.1.2


### PR DESCRIPTION
I believe that Dockerfile.base is missing scikit-learn dependency which was causing the container to fail when deploying. Thus, scikit-learn==1.1.2 dependency had to be included in the requirements.txt.