### PR TITLE
Update Standalone

### DIFF
--- a/manifests/dev/xgboost_deploy.yaml
+++ b/manifests/dev/xgboost_deploy.yaml
@@ -43,20 +43,12 @@ spec:
       containers:
       - name: xgboost-incremental-trainer
         image: quay.io/sustainable_computing_io/kepler_model_server:latest
-        imagePullPolicy: Always
-        volumeMounts:
-          - name: cfm
-            mountPath: /etc/config
-            readOnly: true
-        command: ["python3.8",  "xgboost_incremental_trainer.py"]
-      - name: xgboost-expose-model
-        image: quay.io/sustainable_computing_io/kepler_model_server:latest
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: cfm
             mountPath: /etc/config
             readOnly: true
-        command: ["python3.8",  "xgboost_expose_model.py"]
+        command: ["python3.8",  "xgboost_incremental_trainer.py"]
 
 ---
 kind: Service

--- a/server/train/pipelines/XGBoostRegressionCompDynPipeline/pipe.py
+++ b/server/train/pipelines/XGBoostRegressionCompDynPipeline/pipe.py
@@ -23,7 +23,7 @@ class XGBoostRegressionStandalonePipeline():
         self.train_type = train_type
         self.model_class = 'xgboost'
         self.energy_source = 'rapl'
-        self.feature_group = FeatureGroup.CounterOnly
+        self.feature_group = FeatureGroup.CounterIRQCombined
         self.save_location = save_location
         self.energy_components_labels = EnergyComponentLabelGroups[EnergyComponentLabelGroup.PackageEnergyComponentOnly]
         self.features = FeatureGroups[self.feature_group]

--- a/server/train/pipelines/XGBoostRegressionStandalonePipeline/pipe.py
+++ b/server/train/pipelines/XGBoostRegressionStandalonePipeline/pipe.py
@@ -2,40 +2,47 @@ import os
 import sys
 from typing import List, Tuple, Dict, Any
 import pandas as pd
+import copy
 
 train_path = os.path.join(os.path.dirname(__file__), '../../')
 prom_path = os.path.join(os.path.dirname(__file__), '../../../prom')
 sys.path.append(train_path)
 sys.path.append(prom_path)
 
-from pipeline import TrainPipeline
-from train_types import FeatureGroup, FeatureGroups, PACKAGE_LABEL, ModelOutputType, XGBoostRegressionTrainType
+from train_types import FeatureGroup, FeatureGroups, EnergyComponentLabelGroups, EnergyComponentLabelGroup, ModelOutputType, XGBoostRegressionTrainType
 from pipe_util import XGBoostRegressionModelGenerationPipeline
 from prom.query import PrometheusClient
 from extractor import DefaultExtractor
 
-# Currently Cgroup Metrics are not exported
-class XGBoostRegressionStandalonePipeline(TrainPipeline):
 
-    def __init__(self, train_type: XGBoostRegressionTrainType, save_location: str) -> None:
-        self.train_type = train_type
-        model_name = XGBoostRegressionStandalonePipeline.__name__ + "_" + self.train_type.name
-        model_file = model_name + ".model"
+# Currently Cgroup Metrics are not exported
+class XGBoostRegressionStandalonePipeline():
+
+    def __init__(self, train_type: XGBoostRegressionTrainType, save_location: str, node_level: bool) -> None:
         self.model = None
-        model_class = 'xgboost'
+        self.train_type = train_type
+        self.model_class = 'xgboost'
         self.energy_source = 'rapl'
+        self.feature_group = FeatureGroup.IRQOnly
         self.save_location = save_location
-        self.energy_components = ['package', 'dram']
-        features = FeatureGroups[FeatureGroup.IRQOnly]
-        model_output = ModelOutputType.DynComponentStandalonePower
-        self.labels = PACKAGE_LABEL
-        super().__init__(model_name, model_class, model_file, features, model_output)
+        self.energy_components_labels = EnergyComponentLabelGroups[EnergyComponentLabelGroup.PackageEnergyComponentOnly]
+        self.features = FeatureGroups[self.feature_group]
+        print(self.energy_components_labels)
+        self.model_labels = ["total_package_power"]
+        # Define key model names
+        if node_level:
+            self.model_name = XGBoostRegressionStandalonePipeline.__name__ + "_" + "Node_Level" + "_" + self.train_type.name
+        else:
+            self.model_name = XGBoostRegressionStandalonePipeline.__name__ + "_" + "Container_Level" + "_" + self.train_type.name
+        self.node_level = node_level
         self.initialize_relevant_models()
 
     # This pipeline is responsible for initializing one or more needed models
     # (Can vary depending on variables like isolator)
     def initialize_relevant_models(self) -> None:
-        self.model = XGBoostRegressionModelGenerationPipeline(self.features, self.labels, self.save_location, self.model_name)
+        # Generate models and store in dict
+        self.model = XGBoostRegressionModelGenerationPipeline(self.features, self.model_labels, self.save_location, self.model_name)
+        
 
     def _generate_clean_model_training_data(self, extracted_data: pd.DataFrame) -> pd.DataFrame:
         # Merge Package data columns
@@ -47,27 +54,36 @@ class XGBoostRegressionStandalonePipeline(TrainPipeline):
             if col_name.endswith("_package_power"):
                 package_power_dataset[col_name] = cloned_extracted_data[col_name]
         # Sum to form total_package_power
-        package_power_dataset['total_package_power'] = package_power_dataset.sum(axis=1)
+        package_power_dataset[self.model_labels[0]] = package_power_dataset.sum(axis=1)
         # Append total_package_power to cloned_extracted_data
-        cloned_extracted_data['total_package_power'] = package_power_dataset['total_package_power']
+        cloned_extracted_data[self.model_labels[0]] = package_power_dataset[self.model_labels[0]]
         # Return cloned_extracted_data
         return cloned_extracted_data
+
 
     def train(self, prom_client: PrometheusClient) -> None:
         prom_client.query()
         results = prom_client.snapshot_query_result()
         # results can be used directly by extractor.py
         extractor = DefaultExtractor()
+        # Train all models with extractor
+        extracted_data = extractor.extract(results, self.energy_components_labels, self.feature_group.name, self.energy_source, node_level=self.node_level)
 
-        extracted_data = extractor.extract(results, self.energy_components, self.feature_group.name, self.energy_source, node_level=True)
         if extracted_data is not None:
             clean_df = self._generate_clean_model_training_data(extracted_data)
             self.model.train(self.train_type, clean_df)
         else:
             raise Exception("extractor failed")
-
  
-    def predict(self, list_of_features: List[List[float]]) -> Tuple[List[float], Dict[Any, Any]]:
-        return self.model.predict(list_of_features)
+    # Accepts JSON Input with feature and corresponding prediction
+    def predict(self, features_and_predictions: List[Dict[str,float]]) -> Tuple[List[float], Dict[Any, Any]]:
+        # features Convert to List[List[float]]
+        list_of_predictions = []
+        for prediction in features_and_predictions:
+            feature_values = []
+            for feature in self.features:
+                feature_values.append(prediction[feature])
+            list_of_predictions.append(feature_values)
+        return self.model.predict(list_of_predictions)
         
 

--- a/server/train/train_types.py
+++ b/server/train/train_types.py
@@ -40,6 +40,7 @@ class FeatureGroup(enum.Enum):
    BPFOnly = 5
    KubeletOnly = 6
    IRQOnly = 7
+   CounterIRQCombined = 8
    Unknown = 99
 
 class EnergyComponentLabelGroup(enum.Enum):
@@ -139,6 +140,7 @@ FeatureGroups = {
     FeatureGroup.BPFOnly: deep_sort(BPF_FEATURES),
     FeatureGroup.KubeletOnly: deep_sort(KUBELET_FEATURES),
     FeatureGroup.IRQOnly: deep_sort(IRQ_FEATURES),
+    FeatureGroup.CounterIRQCombined: deep_sort(COUNTER_FEAUTRES + IRQ_FEATURES),
 }
 
 EnergyComponentLabelGroups = {

--- a/server/train/train_types.py
+++ b/server/train/train_types.py
@@ -18,17 +18,19 @@ COUNTER_FEAUTRES = ["cache_miss", "cpu_cycles", "cpu_instr"]
 CGROUP_FEATURES = ["cgroupfs_cpu_usage_us", "cgroupfs_memory_usage_bytes", "cgroupfs_system_cpu_usage_us", "cgroupfs_user_cpu_usage_us"]
 IO_FEATURES = ["bytes_read", "bytes_writes"]
 BPF_FEATURES = ["cpu_time"]
-KUBELET_FEATURES = ['kubelet_memory_bytes', 'kubelet_cpu_usage']
 IRQ_FEATURES = ["block_irq", "net_tx_irq", "net_rx_irq"]
+KUBELET_FEATURES = ['kubelet_memory_bytes', 'kubelet_cpu_usage']
 WORKLOAD_FEATURES = COUNTER_FEAUTRES + CGROUP_FEATURES + IO_FEATURES + BPF_FEATURES + KUBELET_FEATURES
 
 CATEGORICAL_LABEL_TO_VOCAB = {
                     "cpu_architecture": ["Sandy Bridge", "Ivy Bridge", "Haswell", "Broadwell", "Sky Lake", "Cascade Lake", "Coffee Lake", "Alder Lake"] 
                     }
 
-NODE_STAT_POWER_LABEL = ["energy_in_pkg_joule", "energy_in_core_joule", "energy_in_dram_joule", "energy_in_uncore_joule", "energy_in_gpu_joule", "energy_in_other_joule"]
+#NODE_STAT_POWER_LABEL = ["energy_in_pkg_joule", "energy_in_core_joule", "energy_in_dram_joule", "energy_in_uncore_joule", "energy_in_gpu_joule", "energy_in_other_joule"]
 
-PACKAGE_LABEL = ["total_package_power"]
+PACKAGE_ENERGY_COMPONENT_LABEL = ["package"]
+DRAM_ENERGY_COMPONENT_LABEL = ["dram"]
+CORE_ENERGY_COMPONENT_LABEL = ["core"]
 
 class FeatureGroup(enum.Enum):
    Full = 1
@@ -40,6 +42,12 @@ class FeatureGroup(enum.Enum):
    IRQOnly = 7
    Unknown = 99
 
+class EnergyComponentLabelGroup(enum.Enum):
+    PackageEnergyComponentOnly = 1
+    DRAMEnergyComponentOnly = 2
+    CoreEnergyComponentOnly = 3
+    PackageDRAMEnergyComponents = 4
+
 class ModelOutputType(enum.Enum):
     AbsPower = 1
     AbsModelWeight = 2
@@ -49,8 +57,6 @@ class ModelOutputType(enum.Enum):
     DynModelWeight = 6
     DynComponentPower = 7
     DynComponentModelWeight = 8
-    DynComponentStandalonePower = 9
-
 
 
 # XGBoostRegressionTrainType
@@ -120,23 +126,30 @@ DRAM_COMPONENT = 'dram'
 
 POWER_COMPONENTS = [CORE_COMPONENT, DRAM_COMPONENT]
 
-def sort_features(features):
-    sorted_features = features.copy()
-    sorted_features.sort()
-    return sorted_features
+def deep_sort(elements):
+    sorted_elements = elements.copy()
+    sorted_elements.sort()
+    return sorted_elements
 
 FeatureGroups = {
-    FeatureGroup.Full: sort_features(WORKLOAD_FEATURES + SYSTEM_FEATURES),
-    FeatureGroup.WorkloadOnly: sort_features(WORKLOAD_FEATURES),
-    FeatureGroup.CounterOnly: sort_features(COUNTER_FEAUTRES),
-    FeatureGroup.CgroupOnly: sort_features(CGROUP_FEATURES + IO_FEATURES),
-    FeatureGroup.BPFOnly: sort_features(BPF_FEATURES),
-    FeatureGroup.KubeletOnly: sort_features(KUBELET_FEATURES),
-    FeatureGroup.IRQOnly: sort_features(IRQ_FEATURES)
+    FeatureGroup.Full: deep_sort(WORKLOAD_FEATURES + SYSTEM_FEATURES),
+    FeatureGroup.WorkloadOnly: deep_sort(WORKLOAD_FEATURES),
+    FeatureGroup.CounterOnly: deep_sort(COUNTER_FEAUTRES),
+    FeatureGroup.CgroupOnly: deep_sort(CGROUP_FEATURES + IO_FEATURES),
+    FeatureGroup.BPFOnly: deep_sort(BPF_FEATURES),
+    FeatureGroup.KubeletOnly: deep_sort(KUBELET_FEATURES),
+    FeatureGroup.IRQOnly: deep_sort(IRQ_FEATURES),
+}
+
+EnergyComponentLabelGroups = {
+    EnergyComponentLabelGroup.PackageEnergyComponentOnly: deep_sort(PACKAGE_ENERGY_COMPONENT_LABEL),
+    EnergyComponentLabelGroup.DRAMEnergyComponentOnly: deep_sort(DRAM_ENERGY_COMPONENT_LABEL),
+    EnergyComponentLabelGroup.CoreEnergyComponentOnly: deep_sort(CORE_ENERGY_COMPONENT_LABEL),
+    EnergyComponentLabelGroup.PackageDRAMEnergyComponents: deep_sort(PACKAGE_ENERGY_COMPONENT_LABEL + DRAM_ENERGY_COMPONENT_LABEL)
 }
 
 def get_feature_group(features):
-    sorted_features = sort_features(features)
+    sorted_features = deep_sort(features)
     for g, g_features in FeatureGroups.items():
         print(g_features, features)
         if sorted_features == g_features:

--- a/server/xgboost_incremental_trainer.py
+++ b/server/xgboost_incremental_trainer.py
@@ -34,9 +34,9 @@ def read_sample_query_results():
 if __name__ == '__main__':
    prom_client = PrometheusClient()
    while True:
-      xgb_container_pipeline = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "XGBoost/", node_level=False)
+      #xgb_container_pipeline = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "XGBoost/", node_level=False)
       xgb_node_pipeline = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "XGBoost/", node_level=True)
-      xgb_container_pipeline.train(prom_client)
+      #xgb_container_pipeline.train(prom_client)
       xgb_node_pipeline.train(prom_client)
         
       time.sleep(SAMPLING_INTERVAL)

--- a/server/xgboost_incremental_trainer.py
+++ b/server/xgboost_incremental_trainer.py
@@ -2,19 +2,19 @@ import os
 import sys
 import time
 
-#util_path = os.path.join(os.path.dirname(__file__), 'util')
+util_path = os.path.join(os.path.dirname(__file__), 'util')
 train_path = os.path.join(os.path.dirname(__file__), 'train')
 prom_path = os.path.join(os.path.dirname(__file__), 'prom')
-#sys.path.append(util_path)
+sys.path.append(util_path)
 sys.path.append(train_path)
 sys.path.append(prom_path)
 
-from prom.query import PrometheusClient
+from prom.query import PrometheusClient, PROM_QUERY_INTERVAL
+from util.config import getConfig
 
-#SAMPLING_INTERVAL = PROM_QUERY_INTERVAL
-#SAMPLING_INTERVAL = getConfig('SAMPLING_INTERVAL', SAMPLING_INTERVAL)
-#SAMPLING_INTERVAL = int(SAMPLING_INTERVAL)
-SAMPLING_INTERVAL = 20
+SAMPLING_INTERVAL = PROM_QUERY_INTERVAL
+SAMPLING_INTERVAL = getConfig('SAMPLING_INTERVAL', SAMPLING_INTERVAL)
+SAMPLING_INTERVAL = int(SAMPLING_INTERVAL)
 
 
 from train.pipelines.XGBoostRegressionStandalonePipeline.pipe import XGBoostRegressionStandalonePipeline

--- a/server/xgboost_incremental_trainer.py
+++ b/server/xgboost_incremental_trainer.py
@@ -5,7 +5,6 @@ import time
 #util_path = os.path.join(os.path.dirname(__file__), 'util')
 train_path = os.path.join(os.path.dirname(__file__), 'train')
 prom_path = os.path.join(os.path.dirname(__file__), 'prom')
-
 #sys.path.append(util_path)
 sys.path.append(train_path)
 sys.path.append(prom_path)
@@ -20,16 +19,24 @@ SAMPLING_INTERVAL = 20
 
 from train.pipelines.XGBoostRegressionStandalonePipeline.pipe import XGBoostRegressionStandalonePipeline
 from train.pipe_util import XGBoostRegressionTrainType
+import pandas as pd
+def read_sample_query_results():
+   prom_output_path = prom_output_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'tests', 'data', 'prom_output')
 
+   results = dict()
+   metric_filenames = [ metric_filename for metric_filename in os.listdir(prom_output_path) ]
+   for metric_filename in metric_filenames:
+      metric = metric_filename.replace(".csv", "")
+      filepath = os.path.join(prom_output_path, metric_filename)
+      results[metric] = pd.read_csv(filepath)
+   return results
 
 if __name__ == '__main__':
-    prom_client = PrometheusClient()
-    while True:
-       xgb_pipeline = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "XGBoost/")
-       xgb_pipeline.train(prom_client)
+   prom_client = PrometheusClient()
+   while True:
+      xgb_container_pipeline = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "XGBoost/", node_level=False)
+      xgb_node_pipeline = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "XGBoost/", node_level=True)
+      xgb_container_pipeline.train(prom_client)
+      xgb_node_pipeline.train(prom_client)
         
-       time.sleep(SAMPLING_INTERVAL)
-    # xgb_pipeline = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.TrainTestSplitFit, "XGBoost/")
-    # results, model_desc = xgb_pipeline.predict([[18374, 37371, 37372], [483838, 28383, 23774]])
-    # print(results)
-    # print(model_desc)
+      time.sleep(SAMPLING_INTERVAL)


### PR DESCRIPTION
Updated standalone and dyncomp model to develop models for node and container level. Updated predict for standalone model to accept a dict containing feature names and corresponding values. Updated extractor_test.py to contain additional examples. Updated train_types to include enums for Label groups instead of only feature groups. 