### PR TITLE
change config path to match kepler exporter

### DIFF
--- a/manifests/dev/deployment.yaml
+++ b/manifests/dev/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - containerPort: 8100
         volumeMounts:
           - name: cfm
-            mountPath: /etc/config
+            mountPath: /etc/kepler/kepler.config
             readOnly: true
         command: ["python3.8",  "model_server.py"]
 ---

--- a/manifests/dev/trainer-patch.yaml
+++ b/manifests/dev/trainer-patch.yaml
@@ -7,6 +7,6 @@ spec:
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: cfm
-            mountPath: /etc/config
+            mountPath: /etc/kepler/kepler.config
             readOnly: true
         command: ["python3.8",  "online_trainer.py"]

--- a/manifests/dev/xgboost_deploy.yaml
+++ b/manifests/dev/xgboost_deploy.yaml
@@ -46,7 +46,7 @@ spec:
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: cfm
-            mountPath: /etc/config
+            mountPath: /etc/kepler/kepler.config
             readOnly: true
         command: ["python3.8",  "xgboost_incremental_trainer.py"]
 

--- a/manifests/host-local/deployment.yaml
+++ b/manifests/host-local/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           - name: mnt
             mountPath: /mnt
           - name: cfm
-            mountPath: /etc/config
+            mountPath: /etc/kepler/kepler.config
             readOnly: true
         command: ["python3.8",  "model_server.py"]
 ---

--- a/manifests/host-local/trainer-patch.yaml
+++ b/manifests/host-local/trainer-patch.yaml
@@ -9,6 +9,6 @@ spec:
           - name: mnt
             mountPath: /mnt
           - name: cfm
-            mountPath: /etc/config
+            mountPath: /etc/kepler/kepler.config
             readOnly: true
         command: ["python3.8",  "online_trainer.py"]

--- a/manifests/local/deployment.yaml
+++ b/manifests/local/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - containerPort: 8100
         volumeMounts:
           - name: cfm
-            mountPath: /etc/config
+            mountPath: /etc/kepler/kepler.config
             readOnly: true
         command: ["python3.8",  "model_server.py"]
 ---

--- a/manifests/local/trainer-patch.yaml
+++ b/manifests/local/trainer-patch.yaml
@@ -7,6 +7,6 @@ spec:
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: cfm
-            mountPath: /etc/config
+            mountPath: /etc/kepler/kepler.config
             readOnly: true
         command: ["python3.8",  "online_trainer.py"]

--- a/server/util/config.py
+++ b/server/util/config.py
@@ -17,7 +17,7 @@ import os
 # must be writable (for shared volume mount)
 MNT_PATH = "/mnt"
 # can be read only (for configmap mount)
-CONFIG_PATH = "/etc/config"
+CONFIG_PATH = "/etc/kepler/kepler.config"
 
 def getConfig(key, default):
     # check configmap path

--- a/src/util/config.py
+++ b/src/util/config.py
@@ -17,7 +17,7 @@ import os
 # must be writable (for shared volume mount)
 MNT_PATH = "/mnt"
 # can be read only (for configmap mount)
-CONFIG_PATH = "/etc/config"
+CONFIG_PATH = "/etc/kepler/kepler.config"
 
 def getConfig(key, default):
     # check configmap path


### PR DESCRIPTION
Related to path change on kepler exporter in PR https://github.com/sustainable-computing-io/kepler/pull/566, there is also a path change defined in the model server.

This PR made a path change in corresponding test manifests and the source code to read the config from the expecting path. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>