### PR TITLE
fix e2e test and cmd readme

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
       
     - name: Build image
-      run: docker build -t quay.io/sustainable_computing_io/kepler_model_server_base:latest server/dockerfiles -f server/dockerfiles/Dockerfile.base
+      run: docker build -t quay.io/sustainable_computing_io/kepler_model_server_base:latest dockerfiles -f dockerfiles/Dockerfile.base
       
     - name: Login to Quay
       uses: docker/login-action@v1

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -69,6 +69,7 @@ optional arguments:
     output of trained model will be under pipeline folder `default` or can be specified by `-p`
 
     ```bash
+    <pipeline_name>.zip # archived pipeline for model server to load
     <pipeline_name> # provided by -p, --pipeline-name (default: default)
     ├── metadata.json # pipeline metadata such as pipeline name, extractor, isolator, trainer list
     ├── preprocessed_data 
@@ -84,9 +85,10 @@ optional arguments:
     │   │   │   │   ├── metadata.json # model metadata
     │   │   │   │   └── <model_files> 
     │   │   │   │   └── ...
-    │   │   │   ├── <model_name>.zip # archived model
-    ├── rapl_AbsPower_model_metadata.csv # AbsPower models summary
-    ├── rapl_DynPower_model_metadata.csv # DynPower models summary
+    │   │   │   │   └── weight.json # model weight in json format if support for kepler to load
+    │   │   │   ├── <model_name>.zip # archived model for estimator to load
+    ├── <energy_source>_AbsPower_model_metadata.csv # AbsPower models summary
+    ├── <energy_source>_DynPower_model_metadata.csv # DynPower models summary
     └── train_arguments.json
     ```
 

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -4,11 +4,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: kepler_model_server
-  newName: localhost:5001/kepler_model_server
-  newTag: devel
+  newName: quay.io/sustainable_computing_io/kepler_model_server
+  newTag: v0.6
 
 patchesStrategicMerge:
-- ./patch/patch-estimator-sidecar.yaml
-
+- ./patch/patch-model-server.yaml
 resources:
 - ../kepler
+- ../server

--- a/tests/weight_model_request_test.py
+++ b/tests/weight_model_request_test.py
@@ -60,7 +60,11 @@ if __name__ == '__main__':
                 del request_json["system_features"]
                 del request_json["values"]
                 del request_json["system_values"]
-                response = requests.post(get_model_server_req_endpoint(), json=request_json)
+                try:
+                    response = requests.post(get_model_server_req_endpoint(), json=request_json)
+                except Exception as err:
+                    print("cannot get response from model server: {}".format(err))
+                    sys.exit(1) 
                 assert response.status_code == 200, "response {} not OK".format(request_json)
                 loaded_weight = json.loads(response.content)
                 print(loaded_weight)


### PR DESCRIPTION
This PR should test failure in previous merge.
1. change docker file location of base image.
2. restart kepler model server to avoid random failure for unsync latest kepler image.


Additionally, 
- update pipeline structure in entry point readme
- capture connection exception in test source

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>