### PR TITLE
fix model training script and add quick sample

### DIFF
--- a/.github/workflows/docker-base-image.yml
+++ b/.github/workflows/docker-base-image.yml
@@ -17,9 +17,11 @@ jobs:
     - uses: actions/checkout@v3
       
     - name: Build image
-      run: docker build -t quay.io/sustainable_computing_io/kepler_model_server_base:latest dockerfiles -f dockerfiles/Dockerfile.base
+      run: |
+        docker build -t quay.io/sustainable_computing_io/kepler_model_server_base:latest dockerfiles -f dockerfiles/Dockerfile.base
       
     - name: Login to Quay
+      if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/main') }}
       uses: docker/login-action@v1
       with:
           registry: quay.io/sustainable_computing_io
@@ -27,4 +29,5 @@ jobs:
           password: ${{ secrets.BOT_TOKEN }}      
 
     - name: Push to quay
+      if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/main') }}
       run: docker push quay.io/sustainable_computing_io/kepler_model_server_base:latest

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ tests/download/*
 
 src/models
 tests/data/*_output
+model_training/*data*

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,7 +1,6 @@
 FROM --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_model_server_base:latest
 
 WORKDIR /usr/local
-RUN python3.8 -m pip install py-cpuinfo==9.0.0
 
 RUN mkdir -p /usr/local/src
 RUN mkdir -p /usr/local/resource

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,7 +1,6 @@
 FROM --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_model_server_base:latest
 
 WORKDIR /usr/local
-RUN python3.8 -m pip install py-cpuinfo==9.0.0
 
 RUN mkdir -p /usr/local/src
 RUN mkdir -p /usr/local/resource

--- a/model_training/README.md
+++ b/model_training/README.md
@@ -39,24 +39,36 @@ Please confirm the following requirements:
 5. Prometheus server is available at `http://localhost:9090`. Otherwise, set environment `PROM_SERVER`.
    
 ## 2. Run benchmark and collect metric
+### 2.1. For managed cluster, make sure that cluster is in an idle state with only control plane workload
 
-1. For managed cluster, make sure that cluster is in an idle state with only control plane workload
+### 2.2. Run
+### Quick sample
 
-2. Run 
+    ./script.sh quick_collect
 
-    ```
+This is only for testing purpose.
+
+### Full run
+
     ./script.sh collect
-    ```
 
-    It might take an hour to run and collect all benchmarks. Output including CPE CR and Prometheus query response will be in `data` folder by default.
+
+It might take an hour to run and collect all benchmarks. Output including CPE CR and Prometheus query response will be in `data` folder by default.
 
 ## 3. Profile and train 
 
 You can train the model by using docker image which require no environment setup but can be limited by docker limitation or train the model natively by setting up your python environment as follows.
 
-### via docker image
+### < via docker image >
 
-Run 
+#### Quick sample
+
+```
+./script.sh quick_train
+```
+
+
+#### Full run 
 
 ```
 ./script.sh train
@@ -67,7 +79,7 @@ Training output will be in `/data` folder by default. The folder contains:
 - profiles
 - models in a pipeline heirachy 
 
-### native with python environment
+### < native with python environment >
 
 - Prepare environment:
 

--- a/model_training/benchmark/sample.yaml
+++ b/model_training/benchmark/sample.yaml
@@ -1,7 +1,7 @@
 apiVersion: cpe.cogadvisor.io/v1
 kind: Benchmark
 metadata:
-  name: coremark
+  name: sample
   namespace: cpe-operator-system
 spec:
   benchmarkOperator:
@@ -20,15 +20,12 @@ spec:
             - ./coremark-{{ .thread }}thread{{if ne .thread "1"}}s{{end}}.exe
         restartPolicy: Never
   parserKey: coremark
-  repetition: 5
+  repetition: 1
   iterationSpec:
     iterations:
     - name: thread
       values:
       - "4"
-      - "8"
-      - "16"
-      - "32"
     configurations:
     - name: image
       values:

--- a/src/train/pipeline.py
+++ b/src/train/pipeline.py
@@ -137,7 +137,7 @@ class Pipeline():
     
     def process_multiple_query(self, input_query_results_list, energy_components, energy_source, feature_group, aggr=True):
         abs_data, dyn_data, power_labels = self.prepare_data_from_input_list(input_query_results_list, energy_components, energy_source, feature_group, aggr)
-        if abs_data is None or dyn_data is None:
+        if abs_data is None or dyn_data is None or len(abs_data) == 0 or len(dyn_data) == 0:
             return False, None, None   
         self._train(abs_data, dyn_data, power_labels, energy_source, feature_group)
         self.print_pipeline_process_end(energy_source, feature_group, abs_data, dyn_data)
@@ -159,9 +159,9 @@ class Pipeline():
 
         abs_metadata_df, abs_group_path = get_metadata_df(model_toppath, ModelOutputType.AbsPower.name, feature_group, energy_source, self.name)
         dyn_metadata_df, dyn_group_path = get_metadata_df(model_toppath, ModelOutputType.DynPower.name, feature_group, energy_source, self.name)
-        
-        abs_min_row = abs_metadata_df.loc[abs_metadata_df[ERROR_KEY].idxmin()]
-        dyn_min_row = dyn_metadata_df.loc[dyn_metadata_df[ERROR_KEY].idxmin()]
+
+        abs_min_mae = -1 if len(abs_metadata_df) == 0 else abs_metadata_df.loc[abs_metadata_df[ERROR_KEY].idxmin()][ERROR_KEY]
+        dyn_min_mae = -1 if len(dyn_metadata_df) == 0 else dyn_metadata_df.loc[dyn_metadata_df[ERROR_KEY].idxmin()][ERROR_KEY]
 
         messages = [
             "Pipeline {} has finished for modeling {} power by {} feature".format(self.name, energy_source, feature_group),
@@ -171,13 +171,13 @@ class Pipeline():
             "    Input data size: {}".format(len(abs_data)),
             "    Model Trainers: {}".format(abs_trainer_names),
             "    Output: {}".format(abs_group_path),
-            "    Min {}: {}".format(ERROR_KEY, abs_min_row[ERROR_KEY]),
+            "    Min {}: {}".format(ERROR_KEY, abs_min_mae),
             " ",
             "Dynamic Power Modeling:",
             "    Input data size: {}".format(len(dyn_data)),
             "    Model Trainers: {}".format(dyn_trainer_names),
             "    Output: {}".format(dyn_group_path),
-            "    Min {}: {}".format(ERROR_KEY, dyn_min_row[ERROR_KEY]),
+            "    Min {}: {}".format(ERROR_KEY, dyn_min_mae),
         ]
         print_bounded_multiline_message(messages)
 


### PR DESCRIPTION
This PR fixes 
- wrong image in the script use `kepler_model_server` instead of `kepler-model-server`
- handle the case that the training approach is not applicable to input data (for example, too small number of data to train) when summarizing pipeline result
- remove cpuinfo module install in Dockerfile as it is already included in Dockerfile.base
- fix data validation result does not show when run query

Also, this PR adds quick sample data collection and training for experiencing how does model training works.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>