### PR TITLE
change repo to official org

### DIFF
--- a/manifests/base/patch/patch-estimator-sidecar.yaml
+++ b/manifests/base/patch/patch-estimator-sidecar.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   MODEL_CONFIG: |
     NODE_COMPONENTS_ESTIMATOR=true
-    NODE_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sunya-ch/kepler-model-db/main/models/Linux-4.15.0-213-generic-x86_64_v0.6/rapl/AbsPower/KubeletOnly/GradientBoostingRegressorTrainer_1.zip
+    NODE_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/Linux-4.15.0-213-generic-x86_64_v0.6/rapl/AbsPower/KubeletOnly/GradientBoostingRegressorTrainer_1.zip
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/src/util/loader.py
+++ b/src/util/loader.py
@@ -17,7 +17,7 @@ DEFAULT_PIPELINE = 'default'
 CHECKPOINT_FOLDERNAME = 'checkpoint'
 DOWNLOAD_FOLDERNAME = 'download'
 
-default_init_model_url = "https://raw.githubusercontent.com/sunya-ch/kepler-model-db/main/models/"
+default_init_model_url = "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/"
 default_init_pipeline_name = "Linux-4.15.0-213-generic-x86_64_v0.6"
 default_trainer_name = "GradientBoostingRegressorTrainer"
 default_node_type = "1"


### PR DESCRIPTION
This PR changes repo to the official kepler-model-db according to this merge https://github.com/sustainable-computing-io/kepler-model-db/pull/6.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>