### PR TITLE
fix bugs estimator has no energy source

### DIFF
--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -8,7 +8,9 @@ images:
   newTag: v0.6
 
 patchesStrategicMerge:
+- ./patch/patch-estimator-sidecar.yaml
 - ./patch/patch-model-server.yaml
+
 resources:
 - ../kepler
 - ../server

--- a/src/estimate/model/model.py
+++ b/src/estimate/model/model.py
@@ -131,6 +131,6 @@ def load_model(model_path):
     return None
 
 # download model folder has no subfolder of energy source and feature group because it has been already determined by model request
-def load_downloaded_model(output_type):
-    model_path = get_download_output_path(output_type)
+def load_downloaded_model(energy_source, output_type):
+    model_path = get_download_output_path(energy_source, output_type)
     return load_model(model_path)

--- a/src/estimate/model_server_connector.py
+++ b/src/estimate/model_server_connector.py
@@ -14,12 +14,12 @@ from loader import get_download_output_path
 from train_types import ModelOutputType
 
 def make_model_request(power_request):
-    return {"metrics": power_request.metrics + power_request.system_features, "output_type": power_request.output_type, "source": power_request.source, "filter": power_request.filter, "trainer_name": power_request.trainer_name}
+    return {"metrics": power_request.metrics + power_request.system_features, "output_type": power_request.output_type, "source": power_request.energy_source, "filter": power_request.filter, "trainer_name": power_request.trainer_name}
 
 TMP_FILE = 'tmp.zip'
 
-def unpack(output_type, response, replace=True):
-    output_path = get_download_output_path(output_type)
+def unpack(energy_source, output_type, response, replace=True):
+    output_path = get_download_output_path(energy_source, output_type)
     if os.path.exists(output_path):
         if not replace:
             # delete downloaded file
@@ -45,7 +45,7 @@ def make_request(power_request):
         return None
     if response.status_code != 200:
         return None
-    return unpack(output_type, response)
+    return unpack(power_request.energy_source, output_type, response)
 
 def list_all_models():
     if not is_model_server_enabled():

--- a/src/train/extractor/extractor.py
+++ b/src/train/extractor/extractor.py
@@ -20,7 +20,7 @@ def append_ratio_for_pkg(feature_power_data, is_aggr, query_results, power_colum
     unit_vals = get_unit_vals(power_columns)
     if len(unit_vals) == 0:
         # not relate/not append
-        return
+        return feature_power_data
     use_default_ratio = False
     default_ratio = 1/len(unit_vals)
     if usage_ratio_query not in query_results:
@@ -82,7 +82,7 @@ class DefaultExtractor(Extractor):
             return None, None, None
         # join power
         feature_power_data = feature_data.set_index(TIMESTAMP_COL).join(power_data).sort_index().dropna()
-
+        
         # aggregate data if needed
         is_aggr = node_level and aggr
         if is_aggr:
@@ -113,6 +113,7 @@ class DefaultExtractor(Extractor):
 
         # 7. apply utilization ratio to each power unit because the power unit is summation of all container utilization
         feature_power_data = append_ratio_for_pkg(feature_power_data, is_aggr, query_results, power_columns)
+        
         return  feature_power_data, power_columns, corr
     
     def get_workload_feature_data(self, query_results, features):

--- a/src/util/loader.py
+++ b/src/util/loader.py
@@ -122,7 +122,7 @@ def get_model_name(trainer_name, node_type):
 def get_pipeline_path(model_toppath, pipeline_name=DEFAULT_PIPELINE):
     return os.path.join(model_toppath, pipeline_name)
 
-def get_model_group_path(model_toppath, output_type, feature_group, energy_source='rapl', pipeline_name=DEFAULT_PIPELINE, assure=True):
+def get_model_group_path(model_toppath, output_type, feature_group, energy_source, pipeline_name=DEFAULT_PIPELINE, assure=True):
     pipeline_path = get_pipeline_path(model_toppath, pipeline_name)
     energy_source_path = os.path.join(pipeline_path, energy_source)
     output_path = os.path.join(energy_source_path, output_type.name)
@@ -222,10 +222,12 @@ def load_pipeline_metadata(pipeline_path, energy_source, model_type):
     return load_csv(pipeline_path, pipeline_metadata_filename)
 
 def get_download_path():
-    return os.path.join(os.path.dirname(__file__), DOWNLOAD_FOLDERNAME)
+    path = os.path.join(os.path.dirname(__file__), DOWNLOAD_FOLDERNAME)
+    return assure_path(path)
 
-def get_download_output_path(output_type):
-    return os.path.join(get_download_path(), output_type.name)
+def get_download_output_path(energy_source, output_type):
+    energy_source_path = assure_path(os.path.join(get_download_path(), energy_source))
+    return os.path.join(energy_source_path, output_type.name)
 
 def get_url(output_type, feature_group=default_feature_group, trainer_name=default_trainer_name, node_type=default_node_type, model_topurl=default_init_model_url, energy_source="rapl", pipeline_name=default_init_pipeline_name):
     group_path = get_model_group_path(model_topurl, output_type=output_type, feature_group=feature_group, energy_source=energy_source, pipeline_name=pipeline_name, assure=False)

--- a/tests/estimator_power_request_test.py
+++ b/tests/estimator_power_request_test.py
@@ -13,7 +13,7 @@ from extractor_test import test_energy_source
 
 trainer_names = ['SGDRegressorTrainer']
 
-def generate_request(train_name, n=1, metrics=WORKLOAD_FEATURES, system_features=SYSTEM_FEATURES, output_type=ModelOutputType.DynPower.name):
+def generate_request(train_name, n=1, metrics=WORKLOAD_FEATURES, system_features=SYSTEM_FEATURES, output_type=ModelOutputType.DynPower.name, energy_source=test_energy_source):
     request_json = dict() 
     if train_name is not None:
         request_json['trainer_name'] = train_name
@@ -24,7 +24,7 @@ def generate_request(train_name, n=1, metrics=WORKLOAD_FEATURES, system_features
         request_json['system_values'] += [CATEGORICAL_LABEL_TO_VOCAB[m][0]]
     request_json['values'] = [[1.0] *len(metrics)]*n
     request_json['output_type'] = output_type
-    request_json['source'] = test_energy_source
+    request_json['source'] = energy_source
     return request_json
 
 class Client:

--- a/tests/weight_model_request_test.py
+++ b/tests/weight_model_request_test.py
@@ -25,7 +25,7 @@ from train_types import FeatureGroups, FeatureGroup, ModelOutputType
 from loader import get_download_output_path
 from estimate.model_server_connector import list_all_models
 from config import get_model_server_req_endpoint
-
+from extractor_test import test_energy_source
 from estimator_power_request_test import generate_request
 
 os.environ['MODEL_SERVER_URL'] = 'http://localhost:8100'
@@ -40,6 +40,7 @@ weight_available_trainers = ["SGDRegressorTrainer"]
 if __name__ == '__main__':
     # test getting model from server
     os.environ['MODEL_SERVER_ENABLE'] = "true"
+    energy_source = test_energy_source
     
     available_models = list_all_models()
     while len(available_models) == 0:
@@ -49,7 +50,7 @@ if __name__ == '__main__':
 
     for output_type_name, valid_fgs in available_models.items():
         output_type = ModelOutputType[output_type_name]
-        output_path = get_download_output_path(output_type)
+        output_path = get_download_output_path(energy_source, output_type)
         for fg_name, best_model in valid_fgs.items():
             for trainer in weight_available_trainers:
                 print("feature group: ", fg_name)


### PR DESCRIPTION
This PR additionally fixes multiple bugs due to integration test to Kepler.
- feature data is missing when there is no unit values such as in acpi platform energy
- energy source field is missing from estimator PowerRequest
- model path is set `rapl` to default which can be misleading.
- cmd train supported only single energy source
- initUrlKeyMap and estimatorKeyMap are not valid anymore. The model specification is now combination of output type and energy source. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>