### PR TITLE
fix mae calculation bug

### DIFF
--- a/src/train/trainer/scikit.py
+++ b/src/train/trainer/scikit.py
@@ -52,7 +52,7 @@ class ScikitTrainer(Trainer):
         return dict()
 
     def get_mae(self, node_type, component, X_test, y_test):
-        predicted_values = self.predict(node_type, component, X_test)
+        predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
         mae = mean_absolute_error(y_test,predicted_values)
         return mae
 

--- a/tests/extractor_test.py
+++ b/tests/extractor_test.py
@@ -17,7 +17,6 @@ sys.path.append(src_path)
 
 from train import load_class
 from train import DefaultExtractor
-from train.extractor.preprocess import time_filter
 from util.extract_types import component_to_col
 from util.prom_types import node_info_column
 from util.train_types import all_feature_groups
@@ -63,7 +62,7 @@ def save_extract_results(instance, feature_group, extracted_data, node_level, sa
     save_csv(save_path, filename, extracted_data)
 
 def get_expected_power_columns(energy_components=test_energy_components, num_of_unit=test_num_of_unit):
-    return[component_to_col(component, "package", unit_val) for component in energy_components for unit_val in range(0,num_of_unit)]
+    return [component_to_col(component, "package", unit_val) for component in energy_components for unit_val in range(0,num_of_unit)]
 
 def assert_extract(extracted_data, power_columns, energy_components, num_of_unit, feature_group):
     extracted_data_column_names = extracted_data.columns


### PR DESCRIPTION
This PR is to fix the wrong MAE calculation bug as mentioned in https://github.com/sustainable-computing-io/kepler-model-server/issues/120. 

In addition, it adds some minor fixes: remove unused time_filtrer import and add space to return call in extractor_test.py

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>