### PR TITLE
add SmoothExtractor

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -22,6 +22,8 @@ optional arguments:
                         Specify metrix prefix to filter.
   -p PIPELINE_NAME, --pipeline-name PIPELINE_NAME
                         Specify pipeline name.
+  --extractor EXTRACTOR
+                        Specify extractor name (default, smooth).
   --isolator ISOLATOR   Specify isolator name (none, min, profile, trainer).
   --profile PROFILE     Specify profile input (required for trainer and profile isolator).
   -e ENERGY_SOURCE, --energy-source ENERGY_SOURCE

--- a/src/train/__init__.py
+++ b/src/train/__init__.py
@@ -14,6 +14,7 @@ profiler_path = os.path.join(os.path.dirname(__file__), 'profiler')
 sys.path.append(profiler_path)
 
 from extractor import DefaultExtractor
+from smooth_extractor import SmoothExtractor
 from profiler import Profiler, generate_profiles
 from isolator import MinIdleIsolator, ProfileBackgroundIsolator, NoneIsolator
 from train_isolator import TrainIsolator

--- a/src/train/extractor/smooth_extractor.py
+++ b/src/train/extractor/smooth_extractor.py
@@ -1,0 +1,30 @@
+import os 
+import sys
+
+from extractor import DefaultExtractor, find_correlations
+util_path = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
+sys.path.append(util_path)
+
+from train_types import FeatureGroups, FeatureGroup, SYSTEM_FEATURES
+
+class SmoothExtractor(DefaultExtractor):
+
+    def __init__(self, smooth_window=30):
+        self.smooth_window = smooth_window
+
+    # implement extract function
+    def extract(self, query_results, energy_components, feature_group, energy_source, node_level, aggr=True):
+        feature_power_data, power_columns, _ = super().extract(query_results, energy_components, feature_group, energy_source, node_level, aggr)
+
+        features = FeatureGroups[FeatureGroup[feature_group]]
+        smoothed_data = feature_power_data.copy()
+        workload_features = [feature for feature in features if feature not in SYSTEM_FEATURES]
+
+        for col in list(workload_features) + list(power_columns):
+            smoothed_data[col] = feature_power_data[col].rolling(window=self.smooth_window).mean()
+        smoothed_data = smoothed_data.dropna()
+
+        corr = find_correlations(energy_source, feature_power_data, power_columns, workload_features)
+
+        return smoothed_data, power_columns, corr
+

--- a/tests/extractor_test.py
+++ b/tests/extractor_test.py
@@ -16,7 +16,7 @@ sys.path.append(src_path)
 #################################################################
 
 from train import load_class
-from train import DefaultExtractor
+from train import DefaultExtractor, SmoothExtractor
 from util.extract_types import component_to_col
 from util.prom_types import node_info_column
 from util.train_types import all_feature_groups
@@ -34,7 +34,7 @@ assure_path(extractor_output_path)
 if not os.path.exists(extractor_output_path):
     os.mkdir(extractor_output_path)
 
-test_extractors = [DefaultExtractor()]
+test_extractors = [DefaultExtractor(), SmoothExtractor()]
 
 test_energy_source = "rapl"
 test_energy_components = PowerSourceMap[test_energy_source]


### PR DESCRIPTION
According to feature request issue in https://github.com/sustainable-computing-io/kepler-model-server/issues/122, this PR implements SmoothExtractor to smooth the data with specific window size on extraction. 
This is also available to test via the entrypoint `cmd/main.py` with `--extractor smooth`.

As this PR has a base on https://github.com/sustainable-computing-io/kepler-model-server/pull/121 fix, please merge the fix first.


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>