### PR TITLE
fix typo and move TMP file to download path

### DIFF
--- a/src/estimate/estimator.py
+++ b/src/estimate/estimator.py
@@ -64,7 +64,9 @@ def handle_request(data):
                 # find from config
                 output_path = get_achived_model(power_request)
                 if output_path is None:
-                    return {"powers": dict(), "msg": "failed to get model"}
+                    msg = "failed to get model from request {}".format(data)
+                    print(msg)
+                    return {"powers": dict(), "msg": msg}
                 else:
                     print("load model from config: ", output_path)
             else:
@@ -74,7 +76,6 @@ def handle_request(data):
         shutil.rmtree(output_path)
 
     model = loaded_model[output_type.name]
-    print('Estimator model: ', model.model_name)
     powers, msg = model.get_power(power_request.datapoint)
     if msg != "":
         print("{} fail to predict, removed".format(model.model_name))

--- a/src/estimate/model_server_connector.py
+++ b/src/estimate/model_server_connector.py
@@ -10,7 +10,7 @@ util_path = os.path.join(os.path.dirname(__file__), '..', 'util')
 sys.path.append(util_path)
 
 from config import is_model_server_enabled, get_model_server_req_endpoint, get_model_server_list_endpoint
-from loader import get_download_output_path
+from loader import get_download_path, get_download_output_path
 from train_types import ModelOutputType
 
 def make_model_request(power_request):
@@ -20,17 +20,18 @@ TMP_FILE = 'tmp.zip'
 
 def unpack(energy_source, output_type, response, replace=True):
     output_path = get_download_output_path(energy_source, output_type)
+    tmp_filepath = os.path.join(get_download_path(), TMP_FILE)
     if os.path.exists(output_path):
         if not replace:
             # delete downloaded file
-            os.remove(TMP_FILE)
+            os.remove(tmp_filepath)
             return output_path
         # delete existing model
         shutil.rmtree(output_path)
-    with codecs.open(TMP_FILE, 'wb') as f:
+    with codecs.open(tmp_filepath, 'wb') as f:
         f.write(response.content)
-    shutil.unpack_archive(TMP_FILE, output_path)
-    os.remove(TMP_FILE)
+    shutil.unpack_archive(tmp_filepath, output_path)
+    os.remove(tmp_filepath)
     return output_path
 
 def make_request(power_request):

--- a/src/util/config.py
+++ b/src/util/config.py
@@ -21,10 +21,12 @@ MNT_PATH = "/mnt"
 # can be read only (for configmap mount)
 CONFIG_PATH = "/etc/kepler/kepler.config"
 
-modelConfigPrefix = [ "_".join([level, coverage]) for level in ["NODE", "CONTAINER", "PROCESS"] for coverage in ["TOTAL", "COMPONENTS"]]
-
 DEFAULT_TOTAL_SOURCE = "acpi"
 DEFAULT_COMPONENTS_SOURCE = "rapl"
+TOTAL_KEY = "TOTAL"
+COMPONENTS_KEY = "COMPONENTS"
+
+modelConfigPrefix = [ "_".join([level, coverage]) for level in ["NODE", "CONTAINER", "PROCESS"] for coverage in [TOTAL_KEY, COMPONENTS_KEY]]
 
 MODEL_SERVER_SVC = "kepler-model-server.kepler.svc.cluster.local"
 DEFAULT_MODEL_SERVER_PORT = 8100
@@ -110,11 +112,10 @@ def get_init_url(prefix):
     return getConfig(envKey, "")
 
 def get_energy_source(prefix):
-    if "TOAL" in prefix:
+    if TOTAL_KEY in prefix:
         return DEFAULT_TOTAL_SOURCE
-    if "COMPONENTS" in prefix:
+    if COMPONENTS_KEY in prefix:
         return DEFAULT_COMPONENTS_SOURCE
-
 
 # get_init_model_url: get initial model from URL if estimator is enabled
 def get_init_model_url(energy_source, output_type):


### PR DESCRIPTION
According to the issue stated in https://github.com/sustainable-computing-io/kepler/issues/878, this PR removes duplicate hardcoded keyword (total and components) and improves debugging message.

At the same time, this PR also handles the potential read-only file system issue by moving TMP.zip file to the download path which is supposed to be set for write permission.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>