### PR TITLE
add latest tag on workflow and set to default image replacement

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -6,6 +6,7 @@ on:
 env:
   IMAGE_VERSION: '0.6'
   IMAGE_REGISTRY: quay.io/sustainable_computing_io
+  IMAGE_NAME: kepler_model_server
 
 jobs:
   build:
@@ -32,3 +33,10 @@ jobs:
     - name: Push to quay
       if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/main') }}
       run: make push
+
+
+    - name: Tag latest and push to quay
+      if: ${{ (github.repository_owner == 'sustainable-computing-io') && (github.ref == 'refs/heads/main') }}
+      run: |
+        docker tag ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_NAME}}:v${{env.IMAGE_VERSION}} ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_NAME}}:latest
+        docker push ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_NAME}}:latest

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IMAGE_NAME := kepler_model_server
 IMAGE_VERSION := 0.6
 
 IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):v$(IMAGE_VERSION)
+LATEST_TAG_IMAGE := $(IMAGE_REGISTRY)/$(IMAGE_NAME):latest
 TEST_IMAGE := $(IMAGE)-test
 
 CTR_CMD = docker
@@ -72,6 +73,7 @@ test: build-test test-pipeline test-estimator test-model-server test-offline-tra
 # set image
 set-image:
 	cd ./manifests/base && kustomize edit set image kepler_model_server=$(IMAGE)
+	cd ./manifests/server && kustomize edit set image kepler_model_server=$(IMAGE)
 
 # deploy
 _deploy:

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 images:
 - name: kepler_model_server
   newName: quay.io/sustainable_computing_io/kepler_model_server
-  newTag: v0.6
+  newTag: latest
 
 patchesStrategicMerge:
 - ./patch/patch-estimator-sidecar.yaml

--- a/manifests/server/kustomization.yaml
+++ b/manifests/server/kustomization.yaml
@@ -4,24 +4,26 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 vars:
-- name: MODEL_SERVER_NAMESPACE
+- fieldref:
+    fieldPath: metadata.namespace
+  name: MODEL_SERVER_NAMESPACE
   objref:
-    kind: Deployment
     group: apps
-    version: v1
+    kind: Deployment
     name: kepler-model-server
-  fieldref:
-    fieldpath: metadata.namespace
-- name: MODEL_SERVER_PORT
+    version: v1
+- fieldref:
+    fieldPath: spec.template.spec.containers[0].ports[0].containerPort
+  name: MODEL_SERVER_PORT
   objref:
-    kind: Deployment
     group: apps
-    version: v1
+    kind: Deployment
     name: kepler-model-server
-  fieldref:
-    fieldpath: spec.template.spec.containers[0].ports[0].containerPort
+    version: v1
 
 configurations:
 - kustomizeconfig.yaml
-
-
+images:
+- name: kepler_model_server
+  newName: quay.io/sustainable_computing_io/kepler_model_server
+  newTag: latest


### PR DESCRIPTION
This PR is to fix the issue https://github.com/sustainable-computing-io/kepler/issues/888#issuecomment-1694990086.
I added latest tag to the GitHub workflow and, at the same time, set the default image replacement to the latest tag in both base and server kustomization file. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>