### PR TITLE
move API to gh-page and replace with deployment and test

### DIFF
--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -45,6 +45,7 @@ get_server_log() {
 
 wait_for_kepler() {
     kubectl rollout status ds kepler-exporter -n kepler --timeout 5m
+    kubectl describe ds -n kepler kepler-exporter
     kubectl get po -n kepler
 }
 


### PR DESCRIPTION
This PR is to replace complicated API description with quick start point for deployment and test.

The API should be moved to gh-page as pushed by the PR https://github.com/sustainable-computing-io/kepler-doc/pull/98.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>