### PR TITLE
define hints as alternative to isolate container by names

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -3,8 +3,9 @@
 Use kepler model server function as a standalone docker container.
 
 ```
-usage: main.py [-h] [-i INPUT] [-o OUTPUT] [-s SERVER] [--interval INTERVAL] [--step STEP] [--metric-prefix METRIC_PREFIX] [-p PIPELINE_NAME] [--extractor EXTRACTOR] [--isolator ISOLATOR] [--profile PROFILE] [-e ENERGY_SOURCE] [--abs-trainers ABS_TRAINERS]
-               [--dyn-trainers DYN_TRAINERS] [--benchmark BENCHMARK] [-ot OUTPUT_TYPE] [-fg FEATURE_GROUP] [--model-name MODEL_NAME] [--target-data TARGET_DATA] [--id ID] [--version VERSION] [--publisher PUBLISHER] [--include-raw INCLUDE_RAW]
+usage: main.py [-h] [-i INPUT] [-o OUTPUT] [-s SERVER] [--interval INTERVAL] [--step STEP] [--metric-prefix METRIC_PREFIX] [-p PIPELINE_NAME] [--extractor EXTRACTOR] [--isolator ISOLATOR] [--profile PROFILE] [--target-hints TARGET_HINTS] [--bg-hints BG_HINTS]
+               [-e ENERGY_SOURCE] [--abs-trainers ABS_TRAINERS] [--dyn-trainers DYN_TRAINERS] [--benchmark BENCHMARK] [-ot OUTPUT_TYPE] [-fg FEATURE_GROUP] [--model-name MODEL_NAME] [--target-data TARGET_DATA] [--scenario SCENARIO] [--id ID] [--version VERSION]
+               [--publisher PUBLISHER] [--include-raw INCLUDE_RAW]
                command
 
 Kepler model server entrypoint
@@ -30,6 +31,9 @@ optional arguments:
                         Specify extractor name (default, smooth).
   --isolator ISOLATOR   Specify isolator name (none, min, profile, trainer).
   --profile PROFILE     Specify profile input (required for trainer and profile isolator).
+  --target-hints TARGET_HINTS
+                        Specify dynamic workload container name hints (used by TrainIsolator)
+  --bg-hints BG_HINTS   Specify background workload container name hints (used by TrainIsolator)
   -e ENERGY_SOURCE, --energy-source ENERGY_SOURCE
                         Specify energy source.
   --abs-trainers ABS_TRAINERS
@@ -46,6 +50,7 @@ optional arguments:
                         Specify target model name for energy estimation.
   --target-data TARGET_DATA
                         Speficy target plot data (preprocess, estimate)
+  --scenario SCENARIO   Speficy scenario
   --id ID               specify machine id
   --version VERSION     Specify model server version.
   --publisher PUBLISHER

--- a/src/train/isolator/isolator.py
+++ b/src/train/isolator/isolator.py
@@ -54,6 +54,7 @@ def isolate_container(extracted_data, background_containers, label_cols):
     target_containers, background_containers = get_target_containers(extracted_data, background_containers)
     target_data = extracted_data[extracted_data[container_id_colname].isin(target_containers)]
     background_data = extracted_data[~extracted_data[container_id_colname].isin(target_containers)]
+    print("Target containers:", target_containers)
     target_data = squeeze_data(target_data, label_cols)
     background_data = squeeze_data(background_data, label_cols)
     return target_data, background_data

--- a/tests/isolator_test.py
+++ b/tests/isolator_test.py
@@ -94,5 +94,6 @@ def process(test_isolators=test_isolators, customize_isolators=[], extract_path=
 if __name__ == '__main__':
     # Add customize isolator here
     customize_isolators = [TrainIsolator(idle_data=test_idle_data, profiler=DefaultProfiler)]
+    customize_isolators = [TrainIsolator(target_hints=["coremark"])]
     customize_isolators += [ProfileBackgroundIsolator(test_profiles, test_idle_data)]
     process(customize_isolators=customize_isolators)


### PR DESCRIPTION
The added feature by this PR is clarified in https://github.com/sustainable-computing-io/kepler-model-server/issues/150.


Captured output from running `python tests/isolator_test.py`. `target-hints` is set to `["coremark"]`.
```
Target containers: ['f9ad0189dc595151bed60aecd626f9fe15b90855a4bbd2857ed61ed11e55de25/coremark-cpeh-2373875594-v6p99/coremark/default', '2728f549fb2a4257769546649faa778f533834089b65cac0a7f847ff24a1d685/coremark-cpeh-3084828579-n48ff/coremark/default', 'ab14b69a811565d1094b9485ebabf8d0bdae93d19530b603f7e472e21cd2adb6/coremark-cpeh-3101606198-gkszz/coremark/default', 'd6ff74f5dd9e6f0671e1f5449f1ecdbe1ffb859210e515ab3d623dc51d275e6a/coremark-cpeh-984120340-mj9t5/coremark/default', '023c357407ef4591283ed1dabd854df3e04cc566bbfb6d6bd8f0722d727276b0/coremark-cpeh-1000897959-s5jkj/coremark/default', '0aa6ec93e9f2fa2d18bdeafa2c043293178aa4f358f8982bf53626164b68391c/coremark-cpeh-2323542737-v2kfk/coremark/default', '965de3cd7af9eebe931b01a9acae88ff8338c4827d04a279c64c2f4aba524fb3/coremark-cpeh-950565102-55z54/coremark/default', '2e664672ae19db3b40802c095268e3bc83814b6b19d4484713178d6ac4ab6074/coremark-cpeh-2306765118-kgbt6/coremark/default', 'dcde7639260bf92ff55ccadc2ff1c284a73a1f39aaacb4bff4177e221a8ea382/coremark-cpeh-933787483-bcqdg/coremark/default']
```

Note that, `python tests/pipeline_test.py` must be executed first for preparing the test input.

This PR also allows us to separately plot data for specific scenario such as 

Run:
```bash
python cmd/main.py plot_scenario --benchmark stressng --scenario cpu -i stressng_kepler_query -p std_v0.6
```

We can get the plot specific to scenario with `cpu` term filter. 
![None_abs_default_rapl_cpu](https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/d911a7d6-3117-4b0a-be2e-f78167db8171)
![None_abs_default_rapl_BPFOnly_cpu](https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/cd716337-5668-483f-8ca1-e4d137298b9b)


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>