### PR TITLE
add required python versions to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OPTS="ESTIMATOR SERVER" make deploy
 
     For more test information, check [here](./tests/).
 
-### with native python environment
+### with native python (3.8+) environment
 1. Prepare environment
 
     ```bash

--- a/model_training/README.md
+++ b/model_training/README.md
@@ -78,7 +78,7 @@ Training output will be in `/data` folder by default. The folder contains:
 - profiles
 - models in a pipeline heirachy 
 
-### < native with python environment >
+### < native with python (3.8+) environment >
 
 - Prepare environment:
 


### PR DESCRIPTION
No python version requirement is documented, however, [Flask requires python 3.8+](https://flask.palletsprojects.com/en/2.3.x/installation/#python-version). The following error occurs when executing `pip install -r ../dockerfiles/requirements.txt` as instructed [here](https://github.com/sustainable-computing-io/kepler-model-server/blob/10e074224bd13df872f6b2ad63fbb2dbc7a0740b/model_training/README.md?plain=1#L86) with a lower python version:

`Could not find a version that satisfies the requirement flask==2.1.2 (from -r dockerfiles/requirements.txt (line 1)) (from versions: 0.1, 0.2, 0.3, 0.3.1, 0.4, 0.5, 0.5.1, 0.5.2, 0.6, 0.6.1, 0.7, 0.7.1, 0.7.2, 0.8, 0.8.1, 0.9, 0.10, 0.10.1, 0.11, 0.11.1, 0.12, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5, 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 2.0.0rc1, 2.0.0rc2, 2.0.0, 2.0.1, 2.0.2, 2.0.3)
No matching distribution found for flask==2.1.2 (from -r dockerfiles/requirements.txt (line 1))`