### PR TITLE
change node-type check logic

### DIFF
--- a/src/server/model_server.py
+++ b/src/server/model_server.py
@@ -14,7 +14,7 @@ sys.path.append(util_path)
 
 from util.train_types import get_valid_feature_groups, ModelOutputType, FeatureGroups, FeatureGroup
 from util.config import getConfig, model_toppath, ERROR_KEY, MODEL_SERVER_MODEL_REQ_PATH, MODEL_SERVER_MODEL_LIST_PATH, initial_pipeline_url
-from util.loader import parse_filters, is_valid_model, load_json, load_weight, get_model_group_path, get_archived_file, METADATA_FILENAME, CHECKPOINT_FOLDERNAME, get_pipeline_path
+from util.loader import parse_filters, is_valid_model, load_json, load_weight, get_model_group_path, get_archived_file, METADATA_FILENAME, CHECKPOINT_FOLDERNAME, get_pipeline_path, any_node_type, is_matched_type
 
 ###############################################
 # model request 
@@ -42,16 +42,17 @@ MODEL_SERVER_PORT = 8100
 MODEL_SERVER_PORT = getConfig('MODEL_SERVER_PORT', MODEL_SERVER_PORT)
 MODEL_SERVER_PORT = int(MODEL_SERVER_PORT)
 
-def select_best_model(valid_groupath, filters, trainer_name="", node_type=-1, weight=False):
+def select_best_model(valid_groupath, filters, trainer_name="", node_type=any_node_type, weight=False):
     model_names = [f for f in os.listdir(valid_groupath) if \
                     f != CHECKPOINT_FOLDERNAME \
                     and not os.path.isfile(os.path.join(valid_groupath,f)) \
-                    and (trainer_name == "" or trainer_name in f) \
-                    and (node_type == -1 or str(node_type) in f) ]
+                    and (trainer_name == "" or trainer_name in f)]
     # Load metadata of trainers
     best_cadidate = None
     best_response = None
     for model_name in model_names:
+        if not is_matched_type(model_name, node_type):
+            continue
         model_savepath = os.path.join(valid_groupath, model_name)
         metadata = load_json(model_savepath, METADATA_FILENAME)
         if metadata is None or not is_valid_model(metadata, filters) or ERROR_KEY not in metadata:

--- a/src/util/loader.py
+++ b/src/util/loader.py
@@ -22,6 +22,7 @@ default_init_model_url = "https://raw.githubusercontent.com/sustainable-computin
 default_init_pipeline_name = "Linux-4.15.0-213-generic-x86_64_v0.6"
 default_trainer_name = "GradientBoostingRegressorTrainer"
 default_node_type = "1"
+any_node_type = -1
 default_feature_group = FeatureGroup.KubeletOnly
 
 def load_json(path, name):
@@ -122,6 +123,11 @@ def is_valid_model(metadata, filters):
 
 def get_model_name(trainer_name, node_type):
     return "{}_{}".format(trainer_name, node_type)
+
+def is_matched_type(model_name, node_type):
+    if node_type == any_node_type:
+        return True
+    return model_name.split("_")[-1] == str(node_type)
 
 def get_pipeline_path(model_toppath, pipeline_name=DEFAULT_PIPELINE):
     return os.path.join(model_toppath, pipeline_name)


### PR DESCRIPTION
This PR is to fix the issue https://github.com/sustainable-computing-io/kepler-model-server/issues/162.

The previous pipeline format expects `node_type` in the group name but the new design move `node_type` specification to be a part of `model_name`. As a result, I move the logic to check compatibility of node_type to inside the loop.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>