### PR TITLE
add missing integration check (exclude online-trainer)

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -39,6 +39,20 @@ jobs:
           make cleanup
         env:
           OPTS: "ESTIMATOR"
+      - name: test deploying kepler with only server
+        run: |
+          make deploy
+          make e2e-test
+          make cleanup
+        env:
+          OPTS: "SERVER"
+      - name: test deploying kepler with estimator and model server
+        run: |
+          make deploy
+          make e2e-test
+          make cleanup
+        env:
+          OPTS: "ESTIMATOR SERVER"
       - name: test deploying dummy kepler with only estimator
         run: |
           make deploy

--- a/tests/README.md
+++ b/tests/README.md
@@ -260,13 +260,13 @@ Optional arguments:
 scenario|test cases|deploy options|status
 |---|---|---|---|
 Kepler with estimator only|Latest Kepler image is connected to estimator|ESTIMATOR|&#x2714;
-||Latest Kepler image can power from estimator||WIP
+||Estimator can load model from config|ESTIMATOR|&#x2714;
 ||Dummy power request can be made to estimator|ESTIMATOR TEST|&#x2714;
-Kepler with model server only|Latest Kepler image can request weight model from model server|SERVER|WIP
+Kepler with model server only|Latest Kepler image can request weight model from model server|SERVER|&#x2714;
 ||Dummy weight model request can be made to model server|SERVER TEST|&#x2714;
-Kepler with estimator and model server|Dummy power request can be made to estimator|ESTIMATOR SERVER TEST|&#x2714;
-||Estimator can load model from model server||&#x2714;
-||Model server can load initial model||&#x2714;
+Kepler with estimator and model server|Estimator can load model from model server|ESTIMATOR SERVER|&#x2714;
+||Model server can load initial model|ESTIMATOR SERVER|&#x2714;
+||Dummy power request can be made to estimator|ESTIMATOR SERVER TEST|&#x2714;
 Kepler with model server and online trainer|Kepler can provide metric to online trainer to train|ONLINE|WIP
 ||Dummy prometheus server can provide metric to online trainer to train|ONLINE TEST|WIP
 ||Trained model is updated to pipeline and availble on model server||WIP

--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -97,6 +97,7 @@ test() {
     if [ ! -z ${ESTIMATOR} ]; then
         # with estimator
         if [ ! -z ${TEST} ]; then
+            # dummy kepler
             kubectl patch ds kepler-exporter -n kepler --patch-file ${top_dir}/manifests/test/power-request-client.yaml
             if [ ! -z ${SERVER} ]; then
                 restart_model_server
@@ -109,18 +110,26 @@ test() {
         fi
 
         if [ ! -z ${SERVER} ]; then
+            # with server
             wait_for_server
             wait_for_keyword estimator "load model from model server" "estimator should be able to load model from server"
+        else
+            # no server
+            wait_for_keyword estimator "load model from config" "estimator should be able to load model from config"
         fi
     else
         # no estimator
         if [ ! -z ${SERVER} ]; then
+            # with server
             if [ ! -z ${TEST} ]; then 
+                # dummy kepler
                 kubectl patch ds kepler-exporter -n kepler --patch-file ${top_dir}/manifests/test/model-request-client.yaml
                 restart_model_server
                 sleep 1
                 wait_for_kepler
                 wait_for_keyword kepler Done "cannot get model weight"
+            else
+                wait_for_keyword kepler "getWeightFromServer.*core" "kepler should get weight from server"
             fi
         fi
     fi


### PR DESCRIPTION
This PR is to fill the integration test to latest kepler image mentioned in https://github.com/sustainable-computing-io/kepler-model-server/issues/66.

scenario|test cases|deploy options|status
|---|---|---|---|
Kepler with estimator only|Estimator can load model from config|ESTIMATOR|&#x2714;
Kepler with model server only|Latest Kepler image can request weight model from model server|SERVER|&#x2714;

- Remove previous `Latest Kepler image can power from estimator` because Kepler already check that on init. So, it can be covered by `Latest Kepler image is connected to estimator` case.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>