### PR TITLE
fixed off indentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/document.yaml
+++ b/.github/ISSUE_TEMPLATE/document.yaml
@@ -17,7 +17,7 @@ body:
     validations:
       required: true
 
-    - type: textarea
+  - type: textarea
     id: documentFixDetail
     attributes:
       label: How do you suggest this is fixed?


### PR DESCRIPTION
Indentation was misaligned in the document issue template.

Should fix:
<img width="827" alt="image" src="https://github.com/sustainable-computing-io/kepler-model-server/assets/68564154/60f80f23-6297-47d5-b3a7-0447b4c915c0">