### PR TITLE
Enhancement: Optimize Docker image size to reduce it below 1 GB (#154)

### DIFF
--- a/dockerfiles/Dockerfile.base
+++ b/dockerfiles/Dockerfile.base
@@ -1,4 +1,3 @@
-FROM registry.access.redhat.com/ubi8/ubi
-RUN  yum install -y python3.8 python3-devel gcc-c++  && yum clean all
-COPY requirements.txt requirements.txt
-RUN python3.8 -m pip install -r requirements.txt
+FROM python:3.8-slim
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Pull Request: Reduce Image Size and Vulnerability

Changes:
- Utilize `python3.8-slim` as the base image to reduce image size and vulnerability.
- Added `--no-cache-dir` flag during `requirements.txt` installation for further size reduction.

To-Do:
- Remove [`Dockerfiles/Dockerfile.base`](https://github.com/sustainable-computing-io/kepler-model-server/tree/main/dockerfiles) as it's no longer required.

- Delete [`.github/workflows/docker-base-image.yml`](https://github.com/sustainable-computing-io/kepler-model-server/tree/main/.github/workflows) as `python3.8-slim` is used as the base image in the Dockerfile.

This pull request enhances image efficiency and security. Please review and merge as appropriate.
