### PR TITLE
change python version 3.8+ to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ OPTS="ESTIMATOR SERVER" make deploy
 
     For more test information, check [here](./tests/).
 
-### with native python (3.8+) environment
+### with native python environment
+Compatible version: python 3.8
+
+
 1. Prepare environment
 
     ```bash

--- a/model_training/README.md
+++ b/model_training/README.md
@@ -78,7 +78,8 @@ Training output will be in `/data` folder by default. The folder contains:
 - profiles
 - models in a pipeline heirachy 
 
-### < native with python (3.8+) environment >
+### < native with python environment >
+Compatible version: python 3.8
 
 - Prepare environment:
 


### PR DESCRIPTION
Since we found some dependency issue from higher version (3.11), for now, we should specify the compatible version to 3.8 instead. 

_Note:_ 

Some could be fixed in the future by refactoring some implementation such as 
```bash
.../lib/python3.11/site-packages/pandas/core/nanops.py", line 720, in nanmean
  the_sum = _ensure_numeric(the_sum)
```

Some could be fixed by adding some dependency:
```
      ../../scipy/meson.build:130:0: ERROR: Dependency "OpenBLAS" not found, tried pkgconfig and cmake
```
reference: https://github.com/ContinuumIO/anaconda-issues/issues/13157

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>