### PR TITLE
fix unittest (fix dep)/integration test (remove short option)

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -11,12 +11,12 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Test
         run: make build-test
-      - name: Test pipeline
-        run: make test-pipeline
       - name: Test model server
         run: make test-model-server
       - name: Test estimator
         run: make test-estimator
         timeout-minutes: 5
+      - name: Test pipeline
+        run: make test-pipeline
       - name: Test offline trainer
         run: make test-offline-trainer

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ test-estimator: run-estimator run-collector-client clean-estimator
 # test estimator --> model-server
 run-model-server:
 	$(CTR_CMD) run -d --platform linux/amd64  -p 8100:8100 --name model-server $(TEST_IMAGE) python3.8 src/server/model_server.py
+	sleep 5
 
 run-estimator-client:
 	$(CTR_CMD) exec model-server /bin/bash -c "python3.8 -u ./tests/estimator_model_request_test.py"

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -18,4 +18,7 @@ EXPOSE 8101
 # port for Offline Trainer
 EXPOSE 8102
 
+# TODO: remove after kepler_model_server_base:v0.7 built
+RUN pip install Werkzeug==2.2.2
+
 ENTRYPOINT ["python3.8", "cmd/main.py"]

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -21,5 +21,7 @@ EXPOSE 8100
 EXPOSE 8101
 # port for Offline Trainer
 EXPOSE 8102
+# TODO: remove after kepler_model_server_base:v0.7 built
+RUN pip install Werkzeug==2.2.2
 
 CMD [ "python3.8", "-u", "src/server/model_server.py" ]

--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -1,4 +1,5 @@
 flask==2.1.2
+Werkzeug==2.2.2
 protobuf==3.19.4
 pandas==1.4.4
 numpy==1.22.4

--- a/manifests/set.sh
+++ b/manifests/set.sh
@@ -24,7 +24,7 @@ for opt in ${DEPLOY_OPTIONS}; do export $opt=true; done;
 
 echo ${DEPLOY_OPTIONS}
 
-version=$(kubectl version --short | grep 'Client Version' | sed 's/.*v//g' | cut -b -4)
+version=$(kubectl version| grep 'Client Version' | sed 's/.*v//g' | cut -b -4)
 if [ 1 -eq "$(echo "${version} < 1.21" | bc)" ]
 then
     echo "You need to update your kubectl version to 1.21+ to support kustomize"


### PR DESCRIPTION
This PR is to fix previous failed CI. 
The integration test seems to be failed due to dependency of kubectl version. 
The unit test got an error due to new release of Werkzeug. Need to fix the version in base image.

```
Traceback (most recent call last):
  File "src/server/model_server.py", line 1, in <module>
    from flask import Flask, request, json, make_response, send_file
  File "/usr/local/lib/python3.8/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 27, in <module>
    from . import cli
  File "/usr/local/lib/python3.8/site-packages/flask/cli.py", line 17, in <module>
    from .helpers import get_debug_flag
  File "/usr/local/lib/python3.8/site-packages/flask/helpers.py", line 14, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.8/site-packages/werkzeug/urls.py)
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>