### PR TITLE
add page_cache_hit and MAPE

### DIFF
--- a/src/estimate/model/model.py
+++ b/src/estimate/model/model.py
@@ -55,12 +55,13 @@ def get_reconstructed_power_colname(energy_component):
 
 class Model():
     def __init__(self, model_path, model_class, model_name, output_type, model_file, features, fe_files=[],\
-            mae=None, mse=None, mae_val=None, mse_val=None, \
+            mae=None, mse=None, mape=None, mae_val=None, mse_val=None, \
             abs_model=None, abs_mae=None, abs_mae_val=None, abs_mse=None, abs_mse_val=None, abs_max_corr=None, \
             reconstructed_mae=None, reconstructed_mse=None, avg_mae=None, **kwargs):
         self.model_name = model_name
         self.estimator = MODELCLASS[model_class](model_path, model_name, output_type, model_file, features, fe_files)
         self.mae = mae
+        self.mape = mape
         self.mae_val = mae_val
         self.mse = mse
         self.mse_val = mse_val

--- a/src/train/trainer/scikit.py
+++ b/src/train/trainer/scikit.py
@@ -54,6 +54,12 @@ class ScikitTrainer(Trainer):
         predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
         mae = mean_absolute_error(y_test,predicted_values)
         return mae
+    
+    def get_mape(self, node_type, component, X_test, y_test):
+        predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
+        absolute_percentage_errors = np.abs((y_test - predicted_values) / y_test) * 100
+        mape = np.mean(absolute_percentage_errors)
+        return mape
 
     def save_model(self, component_save_path, node_type, component):
         model = self.node_models[node_type][component]

--- a/src/train/trainer/xgboost_interface.py
+++ b/src/train/trainer/xgboost_interface.py
@@ -2,6 +2,7 @@ from sklearn.metrics import mean_absolute_error
 import os
 import sys
 import xgboost as xgb
+import numpy as np
 
 util_path = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
 sys.path.append(util_path)
@@ -72,6 +73,12 @@ class XgboostTrainer(Trainer):
         predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
         mae = mean_absolute_error(y_test, predicted_values)
         return mae
+    
+    def get_mape(self, node_type, component, X_test, y_test):
+        predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
+        absolute_percentage_errors = np.abs((y_test - predicted_values) / y_test) * 100
+        mape = np.mean(absolute_percentage_errors)
+        return mape
 
     def save_model(self, component_save_path, node_type, component):
         model = self.node_models[node_type][component]

--- a/src/util/train_types.py
+++ b/src/util/train_types.py
@@ -16,7 +16,7 @@ SYSTEM_FEATURES = ["node_info", "cpu_scaling_frequency_hertz"]
 
 COUNTER_FEAUTRES = ["cache_miss", "cpu_cycles", "cpu_instructions"]
 CGROUP_FEATURES = ["cgroupfs_cpu_usage_us", "cgroupfs_memory_usage_bytes", "cgroupfs_system_cpu_usage_us", "cgroupfs_user_cpu_usage_us"]
-BPF_FEATURES = ["bpf_cpu_time_us"]
+BPF_FEATURES = ["bpf_cpu_time_us", "bpf_page_cache_hit"]
 IRQ_FEATURES = ["bpf_block_irq", "bpf_net_rx_irq", "bpf_net_tx_irq"]
 KUBELET_FEATURES =['kubelet_memory_bytes', 'kubelet_cpu_usage']
 ACCELERATE_FEATURES = ['accelerator_intel_qat']


### PR DESCRIPTION
This PR partially work on https://github.com/sustainable-computing-io/kepler-model-server/issues/174 and https://github.com/sustainable-computing-io/kepler/issues/943 by adding MAPE to metadata and add newly-introduced page cache hit to the bpf metric group.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>