### PR TITLE
encode xgboost weight, fix MAPE, reorganize exported folder

### DIFF
--- a/cmd/main.py
+++ b/cmd/main.py
@@ -474,7 +474,7 @@ def train(args):
         pipeline.save_metadata()
         # save pipeline
         pipeline.archive_pipeline()
-        print_cols = ["feature_group", "model_name", "mae"]
+        print_cols = ["feature_group", "model_name", "mae", "mape"]
         print("AbsPower pipeline results:")
         metadata_df = load_pipeline_metadata(pipeline.path, energy_source, ModelOutputType.AbsPower.name)
         if metadata_df is not None:

--- a/cmd/main.py
+++ b/cmd/main.py
@@ -813,23 +813,24 @@ def export(args):
     exporter.export(data_path, pipeline_path, machine_path, machine_id=machine_id, version=args.version, publisher=args.publisher, collect_date=collect_date, include_raw=args.include_raw)
 
     args.energy_source = ",".join(PowerSourceMap.keys())
-
+    out_pipeline_path = os.path.join(machine_path, pipeline_name)
+    
     for ot in ModelOutputType:
         args.output_type = ot.name
 
         # plot preprocess data
         args.target_data = "preprocess"
-        args.output = get_preprocess_folder(machine_path)
+        args.output = get_preprocess_folder(out_pipeline_path)
         plot(args)
 
         # plot error
         args.target_data = "error"
-        args.output = os.path.join(machine_path, "error_summary")
+        args.output = os.path.join(out_pipeline_path, "error_summary")
         plot(args)
 
 
     args.target_data = "estimate"
-    args.output = os.path.join(machine_path, "best_estimation")
+    args.output = os.path.join(out_pipeline_path, "best_estimation")
     for ot in ModelOutputType:
         args.output_type = ot.name
         # plot estimate

--- a/src/train/exporter/exporter.py
+++ b/src/train/exporter/exporter.py
@@ -38,7 +38,7 @@ def export(data_path, pipeline_path, machine_path, machine_id, version, publishe
     if include_raw:
         # copy preprocessed_data
         if os.path.exists(preprocess_folder):
-            destination_folder = get_preprocess_folder(machine_path)
+            destination_folder = get_preprocess_folder(out_pipeline_path)
             shutil.copytree(preprocess_folder, destination_folder, dirs_exist_ok=True)
         else:
             print("cannot export raw data: {} does not exist.", preprocess_folder)
@@ -92,7 +92,7 @@ def export(data_path, pipeline_path, machine_path, machine_id, version, publishe
 
     # generate document
     generate_pipeline_page(data_path, machine_path, train_args)
-    generate_validation_results(machine_path, train_args, mae_validated_df_map)
+    generate_validation_results(out_pipeline_path, train_args, mae_validated_df_map)
     append_version_readme(machine_path, train_args, pipeline_metadata, include_raw)
 
 

--- a/src/train/exporter/writer.py
+++ b/src/train/exporter/writer.py
@@ -140,8 +140,8 @@ def format_error_content(train_args, mae_validated_df_map, weight):
             content += dict_to_markdown_table(print_df.sort_values(by=["feature group"]))
     return content
 
-def generate_validation_results(machine_path, train_args, mae_validated_df_map):
-    markdown_filepath = os.path.join(machine_path, "README.md")
+def generate_validation_results(pipeline_path, train_args, mae_validated_df_map):
+    markdown_filepath = os.path.join(pipeline_path, "README.md")
 
     markdown_content = "# Validation results\n\n"
     markdown_content += "## With local estimator\n\n"
@@ -153,13 +153,14 @@ def generate_validation_results(machine_path, train_args, mae_validated_df_map):
 def append_version_readme(machine_path, train_args, pipeline_metadata, include_raw):
     readme_path = os.path.join(_version_path(machine_path), "README.md")
 
-    content_to_append = "{0}|[{1}](./.doc/{1}.md)|{2}|{3}|{4}|[{5}](https://github.com/{5})|[link](./{6}/README.md)\n".format(train_args["machine_id"],  \
+    content_to_append = "{0}|[{1}](./.doc/{1}.md)|{2}|{3}|{4}|[{5}](https://github.com/{5})|[link](./{6}/{7}/README.md)\n".format(train_args["machine_id"],  \
            train_args["pipeline_name"], \
            "&check;" if include_raw else "X", \
            pipeline_metadata["collect_time"], \
            pipeline_metadata["last_update_time"], \
            pipeline_metadata["publisher"],\
-           train_args["machine_id"]\
+           train_args["machine_id"],\
+           pipeline_metadata["name"]
            )
 
     with open(readme_path, 'a') as file:

--- a/src/train/exporter/writer.py
+++ b/src/train/exporter/writer.py
@@ -6,7 +6,7 @@ import pandas as pd
 util_path = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
 sys.path.append(util_path)
 
-from loader import load_json, get_machine_path, default_init_model_url, get_url, trainers_with_weight
+from loader import load_json, get_machine_path, get_url, lr_trainers, xgboost_trainers
 from config import ERROR_KEY
 from train_types import ModelOutputType, FeatureGroup
 
@@ -113,18 +113,20 @@ def generate_pipeline_page(data_path, machine_path, train_args, skip_if_exist=Tr
     write_markdown(markdown_filepath, markdown_content)
 
 def model_url(version, machine_id, pipeline_name, energy_source, output_type, feature_group, model_name, weight):
-    machine_path = get_machine_path(default_init_model_url, version, machine_id, assure=False)
+    repo_url = "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models"
+    machine_path = get_machine_path(repo_url, version, machine_id, assure=False)
     model_url = get_url(ModelOutputType[output_type], FeatureGroup[feature_group], model_name=model_name, model_topurl=machine_path, energy_source=energy_source, pipeline_name=pipeline_name, weight=weight)
     return model_url
 
-def format_error_content(train_args, mae_validated_df_map, weight):
+def format_error_content(train_args, mae_validated_df_map, trainer_list=None):
+    weight = trainer_list is not None
     content = ""
     for energy_source, mae_validated_df_outputs in mae_validated_df_map.items():
         for output_type, mae_validated_df in mae_validated_df_outputs.items():
             content += "### {} {} model\n\n".format(energy_source, output_type)
             df = mae_validated_df
             if weight:
-                df = mae_validated_df[mae_validated_df["model_name"].str.contains('|'.join(trainers_with_weight))]
+                df = mae_validated_df[mae_validated_df["model_name"].str.contains('|'.join(trainer_list))]
             items = []
             min_err_rows = df.loc[df.groupby(["feature_group"])[ERROR_KEY].idxmin()]
             for _, row in min_err_rows.iterrows():
@@ -144,10 +146,12 @@ def generate_validation_results(pipeline_path, train_args, mae_validated_df_map)
     markdown_filepath = os.path.join(pipeline_path, "README.md")
 
     markdown_content = "# Validation results\n\n"
-    markdown_content += "## With local estimator\n\n"
-    markdown_content += format_error_content(train_args, mae_validated_df_map, weight=True)
+    markdown_content += "## With local LR estimator\n\n"
+    markdown_content += format_error_content(train_args, mae_validated_df_map, trainer_list=lr_trainers)
+    markdown_content += "## With local Xgboost estimator\n\n"
+    markdown_content += format_error_content(train_args, mae_validated_df_map, trainer_list=xgboost_trainers)
     markdown_content += "## With sidecar estimator\n\n"
-    markdown_content += format_error_content(train_args, mae_validated_df_map, weight=False)
+    markdown_content += format_error_content(train_args, mae_validated_df_map, trainer_list=None)
     write_markdown(markdown_filepath, markdown_content)
 
 def append_version_readme(machine_path, train_args, pipeline_metadata, include_raw):

--- a/src/train/trainer/scikit.py
+++ b/src/train/trainer/scikit.py
@@ -56,8 +56,13 @@ class ScikitTrainer(Trainer):
         return mae
     
     def get_mape(self, node_type, component, X_test, y_test):
+        y_test = list(y_test)
         predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
-        absolute_percentage_errors = np.abs((y_test - predicted_values) / y_test) * 100
+        non_zero_predicted_values = np.array([predicted_values[i] for i in range(len(predicted_values)) if y_test[i] > 0])
+        if len(non_zero_predicted_values) == 0:
+            return 0
+        non_zero_y_test = np.array([y for y in y_test if y > 0])
+        absolute_percentage_errors = np.abs((non_zero_y_test - non_zero_predicted_values) / non_zero_y_test) * 100
         mape = np.mean(absolute_percentage_errors)
         return mape
 

--- a/src/util/loader.py
+++ b/src/util/loader.py
@@ -27,7 +27,8 @@ default_node_type = "1"
 any_node_type = -1
 default_feature_group = FeatureGroup.BPFOnly
 
-trainers_with_weight = ["SGDRegressorTrainer"]
+lr_trainers = ["SGDRegressorTrainer"]
+xgboost_trainers = ["XgboostFitTrainer"]
 
 def load_json(path, name):
     if ".json" not in name:


### PR DESCRIPTION
This PR includes
- Encode xgboost as requested by https://github.com/sustainable-computing-io/kepler-model-server/pull/190#discussion_r1393200718
- Modify n_estimators parameter of XGBoost to reduce prediction overhead (previously, it was 10x to the other regressor)
- Fix inf MAPE when y_test contains zero.
- Reorganize exported folder
  - Move preprocessed data, figure, and validation result to be under pipeline folder
  - Add local xgboost section

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com> 