### PR TITLE
add isolate_from_data and train_from_data, with refactor entrypoint (tekton prerequisite)

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -2,63 +2,6 @@
 
 Use kepler model server function as a standalone docker container.
 
-```
-usage: main.py [-h] [-i INPUT] [-o OUTPUT] [-s SERVER] [--interval INTERVAL] [--step STEP] [--metric-prefix METRIC_PREFIX] [-p PIPELINE_NAME] [--extractor EXTRACTOR] [--isolator ISOLATOR] [--profile PROFILE] [--target-hints TARGET_HINTS] [--bg-hints BG_HINTS]
-               [-e ENERGY_SOURCE] [--abs-trainers ABS_TRAINERS] [--dyn-trainers DYN_TRAINERS] [--benchmark BENCHMARK] [-ot OUTPUT_TYPE] [-fg FEATURE_GROUP] [--model-name MODEL_NAME] [--target-data TARGET_DATA] [--scenario SCENARIO] [--id ID] [--version VERSION]
-               [--publisher PUBLISHER] [--include-raw INCLUDE_RAW]
-               command
-
-Kepler model server entrypoint
-
-positional arguments:
-  command               The command to execute.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -i INPUT, --input INPUT
-                        Specify input file/folder name.
-  -o OUTPUT, --output OUTPUT
-                        Specify output file/folder name
-  -s SERVER, --server SERVER
-                        Specify prometheus server.
-  --interval INTERVAL   Specify query interval.
-  --step STEP           Specify query step.
-  --metric-prefix METRIC_PREFIX
-                        Specify metrix prefix to filter.
-  -p PIPELINE_NAME, --pipeline-name PIPELINE_NAME
-                        Specify pipeline name.
-  --extractor EXTRACTOR
-                        Specify extractor name (default, smooth).
-  --isolator ISOLATOR   Specify isolator name (none, min, profile, trainer).
-  --profile PROFILE     Specify profile input (required for trainer and profile isolator).
-  --target-hints TARGET_HINTS
-                        Specify dynamic workload container name hints (used by TrainIsolator)
-  --bg-hints BG_HINTS   Specify background workload container name hints (used by TrainIsolator)
-  -e ENERGY_SOURCE, --energy-source ENERGY_SOURCE
-                        Specify energy source.
-  --abs-trainers ABS_TRAINERS
-                        Specify trainer names (use comma(,) as delimiter).
-  --dyn-trainers DYN_TRAINERS
-                        Specify trainer names (use comma(,) as delimiter).
-  --benchmark BENCHMARK
-                        Specify benchmark file name.
-  -ot OUTPUT_TYPE, --output-type OUTPUT_TYPE
-                        Specify output type (AbsPower or DynPower) for energy estimation.
-  -fg FEATURE_GROUP, --feature-group FEATURE_GROUP
-                        Specify target feature group for energy estimation.
-  --model-name MODEL_NAME
-                        Specify target model name for energy estimation.
-  --target-data TARGET_DATA
-                        Speficy target plot data (preprocess, estimate)
-  --scenario SCENARIO   Speficy scenario
-  --id ID               specify machine id
-  --version VERSION     Specify model server version.
-  --publisher PUBLISHER
-                        Specify github account of model publisher
-  --include-raw INCLUDE_RAW
-                        Include raw query data
-```
-
 ## Get started
 
 1. Deploy Kepler with Prometheus in the cluster exporting prometheus to port `:9090`

--- a/cmd/cmd_plot.py
+++ b/cmd/cmd_plot.py
@@ -1,0 +1,113 @@
+import os
+import sys
+
+cur_path = os.path.join(os.path.dirname(__file__), '.')
+sys.path.append(cur_path)
+src_path = os.path.join(os.path.dirname(__file__), '..', 'src')
+sys.path.append(src_path)
+
+from util.prom_types import TIMESTAMP_COL
+from util import PowerSourceMap
+
+
+def ts_plot(data, cols, title, output_folder, name, labels=None, subtitles=None, ylabel=None):
+    plot_height = 3
+    plot_width = 10
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    sns.set(font_scale=1.2)
+    fig, axes = plt.subplots(len(cols), 1, figsize=(plot_width, len(cols)*plot_height))
+    for i in range(0, len(cols)):
+        if len(cols) == 1:
+            ax = axes
+        else:
+            ax = axes[i]
+        if isinstance(cols[i], list):
+            # multiple lines
+            for j in range(0, len(cols[i])):
+                sns.lineplot(data=data, x=TIMESTAMP_COL, y=cols[i][j], ax=ax, label=labels[j])
+            ax.set_title(subtitles[i])
+        else:
+            sns.lineplot(data=data, x=TIMESTAMP_COL, y=cols[i], ax=ax)
+            ax.set_title(cols[i])
+        if ylabel is not None:
+            ax.set_ylabel(ylabel)
+    plt.suptitle(title, x=0.5, y=0.99)
+    plt.tight_layout()
+    filename = os.path.join(output_folder, name + ".png")
+    fig.savefig(filename)
+    plt.close()
+
+def feature_power_plot(data, model_id, output_type, energy_source, feature_cols, actual_power_cols, predicted_power_cols, output_folder, name):
+    plot_height = 5
+    plot_width = 5
+
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    sns.set(font_scale=1.2)
+    row_num = len(feature_cols)
+    col_num = len(actual_power_cols)
+    width = max(10, col_num*plot_width)
+    fig, axes = plt.subplots(row_num, col_num, figsize=(width, row_num*plot_height))
+    for xi in range(0, row_num):
+        feature_col = feature_cols[xi]
+        for yi in range(0, col_num):
+            if row_num == 1:
+                if col_num == 1:
+                    ax = axes
+                else:
+                    ax = axes[yi]
+            else:
+                if col_num == 1:
+                    ax = axes[xi]
+                else:
+                    ax = axes[xi][yi]
+            sorted_data = data.sort_values(by=[feature_col])
+            sns.scatterplot(data=sorted_data, x=feature_col, y=actual_power_cols[yi], ax=ax, label="actual")
+            sns.lineplot(data=sorted_data, x=feature_col, y=predicted_power_cols[yi], ax=ax, label="predicted", color='C1')
+            if xi == 0:
+                ax.set_title(actual_power_cols[yi])
+            if yi == 0:
+                ax.set_ylabel("Power (W)")
+    title = "{} {} prediction correlation \n by {}".format(energy_source, output_type, model_id)
+    plt.suptitle(title, x=0.5, y=0.99)
+    plt.tight_layout()
+    filename = os.path.join(output_folder, name + ".png")
+    fig.savefig(filename)
+    plt.close()
+
+def summary_plot(args, energy_source, summary_df, output_folder, name):
+    if len(summary_df) == 0:
+        print("no summary data to plot")
+        return
+
+    plot_height = 3
+    plot_width = 20
+
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    sns.set(font_scale=1.2)
+
+    energy_components = PowerSourceMap[energy_source]
+    col_num = len(energy_components)
+    fig, axes = plt.subplots(col_num, 1, figsize=(plot_width, plot_height*col_num))
+    for i in range(0, col_num):
+        component = energy_components[i]
+        data = summary_df[(summary_df["energy_source"]==energy_source) & (summary_df["energy_component"]==component)]
+        data = data.sort_values(by=["Feature Group", "MAE"])
+        if col_num == 1:
+            ax = axes
+        else:
+            ax = axes[i]
+        sns.barplot(data=data, x="Feature Group", y="MAE", hue="Model", ax=ax)
+        ax.set_title(component)
+        ax.set_ylabel("MAE (Watt)")
+        ax.set_ylim((0, 100))
+        if i < col_num-1:
+            ax.set_xlabel("")
+        ax.legend(bbox_to_anchor=(1.05, 1.05))
+    plt.suptitle("{} {} error".format(energy_source, args.output_type))
+    plt.tight_layout()
+    filename = os.path.join(output_folder, name + ".png")
+    fig.savefig(filename)
+    plt.close()

--- a/cmd/cmd_util.py
+++ b/cmd/cmd_util.py
@@ -1,0 +1,300 @@
+import os
+import sys
+import datetime
+import pandas as pd
+
+UTC_OFFSET_TIMEDELTA = datetime.datetime.utcnow() - datetime.datetime.now()
+
+cur_path = os.path.join(os.path.dirname(__file__), '.')
+sys.path.append(cur_path)
+src_path = os.path.join(os.path.dirname(__file__), '..', 'src')
+sys.path.append(src_path)
+
+from util.prom_types import node_info_column, prom_responses_to_results
+from util.train_types import ModelOutputType, FeatureGroup
+from util.loader import load_json, get_pipeline_path
+
+def print_file_to_stdout(data_path, args):
+    file_path = os.path.join(data_path, args.output)
+    try:
+        with open(file_path, 'r') as file:
+            contents = file.read()
+            print(contents)
+    except FileNotFoundError:
+        print(f"Error: Output '{file_path}' not found.")
+    except IOError:
+        print(f"Error: Unable to read output '{file_path}'.")
+
+def extract_time(data_path, benchmark_filename):
+    data = load_json(data_path, benchmark_filename)
+    if benchmark_filename != "customBenchmark":
+        start_str = data["metadata"]["creationTimestamp"]
+        start = datetime.datetime.strptime(start_str, '%Y-%m-%dT%H:%M:%SZ')
+        end_str = data["status"]["results"][-1]["repetitions"][-1]["pushedTime"].split(".")[0]
+        end = datetime.datetime.strptime(end_str, '%Y-%m-%d %H:%M:%S')
+    else:
+        start_str = data["startTimeUTC"]
+        start = datetime.datetime.strptime(start_str, '%Y-%m-%dT%H:%M:%SZ')
+        end_str = data["endTimeUTC"]
+        end = datetime.datetime.strptime(end_str, '%Y-%m-%dT%H:%M:%SZ')
+    print(UTC_OFFSET_TIMEDELTA)
+    return start-UTC_OFFSET_TIMEDELTA, end-UTC_OFFSET_TIMEDELTA
+
+def summary_validation(validate_df):
+    if len(validate_df) == 0:
+        print("No data for validation.")
+        return
+    items = []
+    metric_to_validate_pod = {
+        "cgroup": "kepler_container_cgroupfs_cpu_usage_us_total",
+        # "hwc": "kepler_container_cpu_instructions_total",
+        "hwc": "kepler_container_cpu_cycles_total",
+        "kubelet": "kepler_container_kubelet_cpu_usage_total",
+        "bpf": "kepler_container_bpf_cpu_time_us_total",
+    }
+    metric_to_validate_power = {
+        "rapl": "kepler_node_package_joules_total",
+        "platform": "kepler_node_platform_joules_total"
+    }
+    for metric, query in metric_to_validate_pod.items():
+        target_df = validate_df[validate_df["query"]==query]
+        valid_df = target_df[target_df[">0"] > 0]
+        if len(valid_df) == 0:
+            # no data
+            continue
+        availability = len(valid_df)/len(target_df)
+        valid_datapoint = valid_df[">0"].sum()
+        item = dict()
+        item["usage_metric"] = metric
+        item["availability"] = availability
+        item["valid_datapoint"] = valid_datapoint
+        items += [item]
+    summary_df = pd.DataFrame(items)
+    print(summary_df)
+    for metric, query in metric_to_validate_pod.items():
+        target_df = validate_df[validate_df["query"]==query]
+        no_data_df = target_df[target_df["count"] == 0]
+        zero_data_df = target_df[target_df[">0"] == 0]
+        valid_df = target_df[target_df[">0"] > 0]
+        print("==== {} ====".format(metric))
+        if len(no_data_df) > 0:
+            print("{} pods: \tNo data for {}".format(len(no_data_df), pd.unique(no_data_df["scenarioID"])))
+        if len(zero_data_df) > 0:
+            print("{} pods: \tZero data for {}".format(len(zero_data_df), pd.unique(zero_data_df["scenarioID"])))
+
+        print("{} pods: \tValid\n".format(len(valid_df)))
+        print("Valid data points:")
+        print( "Empty" if len(valid_df[">0"]) == 0 else valid_df.groupby(["scenarioID"]).sum()[[">0"]])
+    for metric, query in metric_to_validate_power.items():
+        target_df = validate_df[validate_df["query"]==query]
+        print("{} data: \t{}".format(metric, target_df[">0"].values))
+
+def get_validate_df(data_path, benchmark_filename, query_response):
+    items = []
+    query_results = prom_responses_to_results(query_response)
+    container_queries = [query for query in query_results.keys() if "container" in query]
+    status_data = load_json(data_path, benchmark_filename)
+    if status_data is None or status_data.get("status", None) == None:
+        # select all with keyword
+        for query in container_queries:
+            df = query_results[query]
+            if len(df) == 0:
+                # set validate item // no value
+                item = dict()
+                item["pod"] = benchmark_filename
+                item["scenarioID"] = ""
+                item["query"] = query
+                item["count"] = 0
+                item[">0"] = 0
+                item["total"] = 0
+                items += [item]
+                continue
+            filtered_df = df[df["pod_name"].str.contains(benchmark_filename)]
+            # set validate item
+            item = dict()
+            item["pod"] = benchmark_filename
+            item["scenarioID"] = ""
+            item["query"] = query
+            item["count"] = len(filtered_df)
+            item[">0"] = len(filtered_df[filtered_df[query] > 0])
+            item["total"] = filtered_df[query].max()
+            items += [item]
+    else:
+        cpe_results = status_data["status"]["results"]
+        for result in cpe_results:
+            scenarioID = result["scenarioID"]
+            scenarios = result["scenarios"]
+            configurations = result["configurations"]
+            for k, v in scenarios.items():
+                result[k] = v
+            for k, v in configurations.items():
+                result[k] = v
+            repetitions = result["repetitions"]
+            for rep in repetitions:
+                podname = rep["pod"]
+                for query in container_queries:
+                    df = query_results[query]
+                    if len(df) == 0:
+                        # set validate item // no value
+                        item = dict()
+                        item["pod"] = podname
+                        item["scenarioID"] = scenarioID
+                        item["query"] = query
+                        item["count"] = 0
+                        item[">0"] = 0
+                        item["total"] = 0
+                        items += [item]
+                        continue
+                    filtered_df = df[df["pod_name"]==podname]
+                    # set validate item
+                    item = dict()
+                    item["pod"] = podname
+                    item["scenarioID"] = scenarioID
+                    item["query"] = query
+                    item["count"] = len(filtered_df)
+                    item[">0"] = len(filtered_df[filtered_df[query] > 0])
+                    item["total"] = filtered_df[query].max()
+                    items += [item]
+    energy_queries = [query for query in query_results.keys() if "_joules" in query]
+    for query in energy_queries:
+        df = query_results[query]
+        if len(df) == 0:
+            # set validate item // no value
+            item = dict()
+            item["pod"] = ""
+            item["scenarioID"] = ""
+            item["query"] = query
+            item["count"] = 0
+            item[">0"] = 0
+            item["total"] = 0
+            items += [item]
+            continue
+        # set validate item
+        item = dict()
+        item["pod"] = ""
+        item["scenarioID"] = ""
+        item["query"] = query
+        item["count"] = len(df)
+        item[">0"] = len(df[df[query] > 0])
+        item["total"] = df[query].max()
+        items += [item]
+    other_queries = [query for query in query_results.keys() if query not in container_queries and query not in energy_queries]
+    for query in other_queries:
+        df = query_results[query]
+        if len(df) == 0:
+            # set validate item // no value
+            item = dict()
+            item["pod"] = benchmark_filename
+            item["scenarioID"] = ""
+            item["query"] = query
+            item["count"] = 0
+            item[">0"] = 0
+            item["total"] = 0
+            items += [item]
+            continue
+        # set validate item
+        item = dict()
+        item["pod"] = benchmark_filename
+        item["scenarioID"] = ""
+        item["query"] = query
+        item["count"] = len(df)
+        item[">0"] = len(df[df[query] > 0])
+        item["total"] = df[query].max()
+        items += [item]
+    validate_df = pd.DataFrame(items)
+    if not validate_df.empty:
+        print(validate_df.groupby(["scenarioID", "query"]).sum()[["count", ">0"]])
+    return validate_df
+
+def check_ot_fg(args, valid_fg):
+    ot = None
+    fg = None
+    if args.output_type:
+        try:
+            ot = ModelOutputType[args.output_type]
+        except KeyError:
+            print("invalid output type. please use AbsPower or DynPower", args.output_type)
+            exit()
+    if args.feature_group:
+        valid_fg_name_list = [fg.name for fg in valid_fg]
+        try:
+            fg = FeatureGroup[args.feature_group]
+            if args.feature_group not in valid_fg_name_list:
+                print("feature group: {} is not available in your data. please choose from the following list: {}".format(args.feature_group, valid_fg_name_list))
+                exit()
+        except KeyError:
+            print("invalid feature group: {}. valid feature group are {}.".format((args.feature_group, [fg.name for fg in valid_fg])))
+            exit()
+    return ot, fg
+
+def assert_train(trainer, data, energy_components):
+    import pandas as pd
+    node_types = pd.unique(data[node_info_column])
+    for node_type in node_types:
+        node_type_str = int(node_type)
+        node_type_filtered_data = data[data[node_info_column] == node_type]
+        X_values = node_type_filtered_data[trainer.features].values
+        for component in energy_components:
+            output = trainer.predict(node_type_str, component, X_values)
+            if output is not None:
+                assert len(output) == len(X_values), "length of predicted values != features ({}!={})".format(len(output), len(X_values))
+
+def get_isolator(data_path, isolator, profile, pipeline_name, target_hints, bg_hints, abs_pipeline_name):
+    pipeline_path = get_pipeline_path(data_path, pipeline_name=pipeline_name)
+    from train import MinIdleIsolator, NoneIsolator, DefaultProfiler, ProfileBackgroundIsolator, TrainIsolator, generate_profiles
+    supported_isolator = {
+        MinIdleIsolator().get_name(): MinIdleIsolator(),
+        NoneIsolator().get_name(): NoneIsolator(),
+    }
+
+    if target_hints:
+        target_hints = target_hints.split(",")
+    else:
+        target_hints = []
+
+    if bg_hints:
+        bg_hints = bg_hints.split(",")
+    else:
+        bg_hints = []
+
+    profiles = dict()
+    if profile:
+        idle_response = load_json(data_path, profile)
+        idle_data = prom_responses_to_results(idle_response)
+        if idle_data is None:
+            print("failed to read idle data")
+            return None
+        profile_map = DefaultProfiler.process(idle_data, profile_top_path=pipeline_path)
+        profiles = generate_profiles(profile_map)
+        profile_isolator =  ProfileBackgroundIsolator(profiles, idle_data)
+        supported_isolator[profile_isolator.get_name()] = profile_isolator
+        if abs_pipeline_name != "":
+            trainer_isolator = TrainIsolator(idle_data=idle_data, profiler=DefaultProfiler, target_hints=target_hints, bg_hints=bg_hints, abs_pipeline_name=abs_pipeline_name)
+            supported_isolator[trainer_isolator.get_name()] = trainer_isolator
+    else:
+        if abs_pipeline_name != "":
+            trainer_isolator = TrainIsolator(target_hints=target_hints, bg_hints=bg_hints, abs_pipeline_name=abs_pipeline_name)
+            supported_isolator[trainer_isolator.get_name()] = trainer_isolator
+
+    if isolator not in supported_isolator:
+        print("isolator {} is not supported. supported isolator: {}".format(isolator, supported_isolator.keys()))
+        return None
+    return supported_isolator[isolator]
+
+def get_extractor(extractor):
+    from train import DefaultExtractor, SmoothExtractor
+    supported_extractor = {
+        DefaultExtractor().get_name(): DefaultExtractor(),
+        SmoothExtractor().get_name(): SmoothExtractor()
+    }
+    if extractor not in supported_extractor:
+        print("extractor {} is not supported. supported extractor: {}".format(extractor, supported_extractor.keys()))
+        return None
+    return supported_extractor[extractor]
+
+def get_pipeline(data_path, pipeline_name, extractor, profile, target_hints, bg_hints, abs_pipeline_name, isolator, abs_trainer_names, dyn_trainer_names, energy_sources, valid_feature_groups):
+    from train import NewPipeline
+    isolator = get_isolator(data_path, isolator, profile, pipeline_name, target_hints, bg_hints, abs_pipeline_name)
+    extractor = get_extractor(extractor)
+    pipeline = NewPipeline(pipeline_name, abs_trainer_names, dyn_trainer_names, extractor=extractor, isolator=isolator, target_energy_sources=energy_sources ,valid_feature_groups=valid_feature_groups)
+    return pipeline

--- a/src/train/trainer/__init__.py
+++ b/src/train/trainer/__init__.py
@@ -242,7 +242,9 @@ class Trainer(metaclass=ABCMeta):
         item = self.get_basic_metadata(node_type)
         for component in self.energy_components:
             mae = self.get_mae(node_type, component, X_test_map[component], y_test_map[component])
+            mae = round(mae, 2)
             mape = self.get_mape(node_type, component, X_test_map[component], y_test_map[component])
+            mape = round(mape, 2)
             if max_mae is None or mae > max_mae:
                 max_mae = mae
             if max_mape is None or mape > max_mape:

--- a/src/train/trainer/scikit.py
+++ b/src/train/trainer/scikit.py
@@ -60,7 +60,7 @@ class ScikitTrainer(Trainer):
         predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
         non_zero_predicted_values = np.array([predicted_values[i] for i in range(len(predicted_values)) if y_test[i] > 0])
         if len(non_zero_predicted_values) == 0:
-            return 0
+            return -1
         non_zero_y_test = np.array([y for y in y_test if y > 0])
         absolute_percentage_errors = np.abs((non_zero_y_test - non_zero_predicted_values) / non_zero_y_test) * 100
         mape = np.mean(absolute_percentage_errors)

--- a/src/train/trainer/xgboost_interface.py
+++ b/src/train/trainer/xgboost_interface.py
@@ -80,7 +80,7 @@ class XgboostTrainer(Trainer):
         predicted_values = self.predict(node_type, component, X_test, skip_preprocess=True)
         non_zero_predicted_values = np.array([predicted_values[i] for i in range(len(predicted_values)) if y_test[i] > 0])
         if len(non_zero_predicted_values) == 0:
-            return 0
+            return -1
         non_zero_y_test = np.array([y for y in y_test if y > 0])
         absolute_percentage_errors = np.abs((non_zero_y_test - non_zero_predicted_values) / non_zero_y_test) * 100
         mape = np.mean(absolute_percentage_errors)

--- a/src/util/extract_types.py
+++ b/src/util/extract_types.py
@@ -37,3 +37,8 @@ def get_num_of_unit(energy_source, label_cols):
     energy_components = PowerSourceMap(energy_source)
     num_of_unit = len(label_cols)/len(energy_components)
     return num_of_unit
+
+def get_expected_power_columns(energy_components, num_of_unit=1):
+    # TODO: if ratio applied, 
+    # return [component_to_col(component, "package", unit_val) for component in energy_components for unit_val in range(0,num_of_unit)]
+    return [component_to_col(component) for component in energy_components]


### PR DESCRIPTION
This PR is a prerequisite for leveraging Tekton pipeline (https://github.com/sustainable-computing-io/kepler-model-server/issues/194) including:

**significant changes:**
- refactor cmd (entrypoint) code by separating cmd_plot.py and cmd_util.py for sub functions
- add `data-path`, `abs-pipeline-name` parameters to specify any data path by argument and to separate pipeline for isolation and output pipeline, respectively
- add `isolate_from_data` and  `train_from_data` command to separate run isolator and trainer process out of the pipeline based on preprocessed dataframe.  `train_from_data` introduces a new parameter `trainers`.
- allow to create a new data folder if not exist for `query` command
- add missing `update_thirdparty_metrics` call in `train` command
- auto fill default_trainers if abs_trainers/dyn_trainers is "default"

**minor changes:**
- round MAE, MAPE to 2 digits
- return -1 if cannot compute MAPE value

**documentation changes:**
- remove outdated command in cmd/README.md
- add description to each command function

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>