### PR TITLE
upgrade xgboost to 2.0.1

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -3,14 +3,34 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.changes.outputs.src }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          src:
+            - 'dockerfiles/requirements.txt'
+            - 'dockerfiles/Dockerfile.base'
+            - '.github/workflows/unittest.yaml'
+
   run-test-cases:
     runs-on: ubuntu-latest
+    needs: changes
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker
         uses: docker/setup-buildx-action@v3
-      - name: Test
+      - name: Build test with base image
+        if: ${{ needs.changes.outputs.src == 'false' }}
         run: make build-test
+      - name: Build test without base image
+        if: ${{ needs.changes.outputs.src == 'true' }}
+        run: make build-test-nobase
       - name: Test model server
         run: make test-model-server
       - name: Test estimator

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ DOCKERFILES_PATH := "./dockerfiles"
 build:
 	$(CTR_CMD) build -t $(IMAGE) -f $(DOCKERFILES_PATH)/Dockerfile .
 
+build-test-nobase:
+	$(CTR_CMD) build -t $(TEST_IMAGE) -f $(DOCKERFILES_PATH)/Dockerfile.test-nobase .
+
 build-test:
 	$(CTR_CMD) build -t $(TEST_IMAGE) -f $(DOCKERFILES_PATH)/Dockerfile.test .
 

--- a/dockerfiles/Dockerfile.test-nobase
+++ b/dockerfiles/Dockerfile.test-nobase
@@ -1,0 +1,28 @@
+# Include base requirements
+FROM python:3.8-slim
+COPY dockerfiles/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+WORKDIR /usr/local
+
+RUN mkdir -p /usr/local/src
+RUN mkdir -p /usr/local/resource
+
+RUN mkdir -p resource/profiles
+COPY src/estimate src/estimate
+COPY src/server src/server
+COPY src/train src/train
+COPY src/util src/util
+
+RUN mkdir -p tests/data
+COPY tests/data/prom_output tests/data/prom_output 
+COPY tests/*.py tests/
+
+# port for Model Server
+EXPOSE 8100
+# port for Online Trainer (TODO: reserved for event-based online training)
+EXPOSE 8101
+# port for Offline Trainer
+EXPOSE 8102
+
+CMD [ "python3.8", "-u", "src/server/model_server.py" ]

--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -8,7 +8,7 @@ prometheus-api-client==0.5.1
 joblib==1.2.0
 pyyaml_env_tag==0.1
 scipy==1.9.1
-xgboost==1.6.2
+xgboost==2.0.1
 scikit-learn==1.1.2
 py-cpuinfo==9.0.0
 seaborn==0.12.2


### PR DESCRIPTION
According to https://github.com/sustainable-computing-io/kepler-model-server/issues/187, this PR made the version upgrade of xgboost and update unit test workflow to build test image without base image if there is a change on base image related files (such as requirement.txt).

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>