### PR TITLE
add node type indexing

### DIFF
--- a/.github/workflows/collect-data-self-hosted.yml
+++ b/.github/workflows/collect-data-self-hosted.yml
@@ -147,7 +147,7 @@ jobs:
         working-directory: model_training/tekton
         run: |
           kubectl apply -f tasks
-          kubectl apply -f tasks/s3-pusher
+          kubectl apply -f tasks/s3
           kubectl apply -f pipelines
       - name: Run Tekton Pipeline with S3Push
         run: |
@@ -166,7 +166,7 @@ jobs:
                 claimName: task-pvc
             params:
             - name: MODEL_SERVER_IMAGE
-              value: ${{ inputs.model_server_image }}}
+              value: ${{ inputs.model_server_image }}
             - name: COS_PROVIDER
               value: aws
             - name: COS_SECRET_NAME
@@ -176,6 +176,10 @@ jobs:
             pipelineRef:
               name: collect-data-pipeline
           EOF
+
+      - name: Wait for PipelineRun
+        run: |
+          ./hack/k8s_helper.sh wait_for_pipelinerun self-hosted-aws-collect
 
   destroy-runner:
     if: always()

--- a/.github/workflows/collect-train.yml
+++ b/.github/workflows/collect-train.yml
@@ -22,6 +22,7 @@ jobs:
       aws_region: ${{ secrets.AWS_REGION }}
       
   train-model:
+    needs: [collect-data]
     strategy:
       matrix:
         instance_type: [i3.metal]

--- a/.github/workflows/tekton-test.yml
+++ b/.github/workflows/tekton-test.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: string
         default: AbsPower
+      trainers:
+        description: 'Model trainer list (delimit: ,)'
+        required: false
+        type: string
+        default: XgboostFitTrainer        
 
 env:
   BASE_IMAGE: ${{ inputs.image_repo }}/kepler_model_server_base:${{ inputs.image_tag }}
@@ -172,3 +177,34 @@ jobs:
               name: single-retrain-pipeline
           EOF
           ./hack/k8s_helper.sh wait_for_pipelinerun test-retrain
+
+      - name: Run Tekton Complete Retrain
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: tekton.dev/v1
+          kind: PipelineRun
+          metadata:
+            name: test-complete-retrain
+          spec:
+            timeouts:
+              pipeline: "6h"
+              tasks: "5h50m"
+            workspaces:
+            - name: mnt
+              persistentVolumeClaim:
+                claimName: task-pvc
+            params:
+            - name: MODEL_SERVER_IMAGE
+              value: $IMAGE
+            - name: PIPELINE_NAME
+              value: ${{ inputs.pipeline_name }}
+            - name: MACHINE_ID
+              value: test
+            - name: ABS_TRAINERS
+              value: ${{ inputs.trainers }}
+            - name: DYN_TRAINERS
+              value: ${{ inputs.trainers }}
+            pipelineRef:
+              name: complete-retrain-pipeline
+          EOF
+          ./hack/k8s_helper.sh wait_for_pipelinerun test-complete-retrain

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -171,7 +171,7 @@ jobs:
                 claimName: task-pvc
             params:
             - name: MODEL_SERVER_IMAGE
-              value: ${{ inputs.model_server_image }}}
+              value: ${{ inputs.model_server_image }}
             - name: PIPELINE_NAME
               value: ${{ inputs.pipeline_name }}
             - name: COS_PROVIDER

--- a/model_training/tekton/README.md
+++ b/model_training/tekton/README.md
@@ -62,17 +62,22 @@ Previous step: [Prepare cluster](./README.md#1-prepare-cluster)
         bucketName: kepler-power-model
     ```
 
-    3.2. Uncomment COS-related varaiable values in `pipelineruns/kepler-default.yaml`
+    3.2. Uncomment COS-related varaiable values in `examples/single-train/default.yaml`
 
 ## 2. Deploy Tekton tasks and pipelines
 
 ```
 kubectl apply -f tasks
-kubectl apply -f tasks/s3-pusher
+kubectl apply -f tasks/s3
 kubectl apply -f pipelines
 ```
 
-## 3. Run Tekton pipeline
+## 3. Quick test
+```
+kubectl apply -f examples/single-train/abs-power.yaml
+```
+
+## 4. Run Tekton pipeline
 
 The minimum required pipelinerun for default power model of Kepler on VM is as below:
 ![](../../fig/tekton-kepler-default.png)

--- a/model_training/tekton/examples/complete-pipelinerun.yaml
+++ b/model_training/tekton/examples/complete-pipelinerun.yaml
@@ -1,3 +1,5 @@
+# example-complete-train-pipeline
+#   running pipelines with all default value to train AbsPower/DynPower for all energysource and featuregroup
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:

--- a/model_training/tekton/examples/test-retrain.yaml
+++ b/model_training/tekton/examples/test-retrain.yaml
@@ -1,3 +1,5 @@
+# example-abs-train-pipeline:
+#   running pipelines with all default value to train AbsPower model (intel_rapl, BPFOnly)
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:

--- a/model_training/tekton/pipelines/collect.yaml
+++ b/model_training/tekton/pipelines/collect.yaml
@@ -65,6 +65,8 @@ spec:
           value: $(params.THIRDPARTY_METRICS)
         - name: MODEL_SERVER_IMAGE
           value: $(params.MODEL_SERVER_IMAGE)
+        - name: MACHINE_ID
+          value: $(params.MACHINE_ID)
       taskSpec:
         workspaces:
           - name: mnt
@@ -73,6 +75,7 @@ spec:
           - name: IDLE_COLLECT_INTERVAL
           - name: THIRDPARTY_METRICS
           - name: MODEL_SERVER_IMAGE
+          - name: MACHINE_ID
         results:
           - name: stress-start-time
             description: The time recorded before running the workload
@@ -92,6 +95,7 @@ spec:
             - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
             - --benchmark=idle
             - -o=idle
+            - --id=$(params.MACHINE_ID)
             command: ["python3.8"]
             env:
             - name: PROM_SERVER
@@ -122,6 +126,8 @@ spec:
           value: $(params.THIRDPARTY_METRICS)
         - name: MODEL_SERVER_IMAGE
           value: $(params.MODEL_SERVER_IMAGE)
+        - name: MACHINE_ID
+          value: $(params.MACHINE_ID)
       taskSpec:
         workspaces:
           - name: mnt
@@ -131,6 +137,7 @@ spec:
             default: stressng
           - name: THIRDPARTY_METRICS
           - name: MODEL_SERVER_IMAGE
+          - name: MACHINE_ID
         steps:
           - name: collect-stressng
             image: $(params.MODEL_SERVER_IMAGE)
@@ -141,6 +148,7 @@ spec:
             - --start-time=$(tasks.presteps.results.stress-start-time)
             - --end-time=$(tasks.run-stressng.results.stress-end-time)
             - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
+            - --id=$(params.MACHINE_ID)
             - --benchmark=stressng
             - -o=kepler_query
             command: ["python3.8"]

--- a/model_training/tekton/pipelines/complete-retrain.yaml
+++ b/model_training/tekton/pipelines/complete-retrain.yaml
@@ -121,6 +121,8 @@ spec:
         value: $(params.ENERGY_SOURCE)
       - name: THIRDPARTY_METRICS
         value: $(params.THIRDPARTY_METRICS)
+      - name: MACHINE_ID
+        value: $(params.MACHINE_ID)
     - name: ibmcloud-s3-push
       runAfter: [train-from-query]
       when:

--- a/model_training/tekton/pipelines/complete-train.yaml
+++ b/model_training/tekton/pipelines/complete-train.yaml
@@ -86,6 +86,8 @@ spec:
           value: $(params.THIRDPARTY_METRICS)
         - name: MODEL_SERVER_IMAGE
           value: $(params.MODEL_SERVER_IMAGE)
+        - name: MACHINE_ID
+          value: $(params.MACHINE_ID)
       taskSpec:
         workspaces:
           - name: mnt
@@ -94,6 +96,7 @@ spec:
           - name: IDLE_COLLECT_INTERVAL
           - name: THIRDPARTY_METRICS
           - name: MODEL_SERVER_IMAGE
+          - name: MACHINE_ID
         results:
           - name: stress-start-time
             description: The time recorded before running the workload
@@ -108,6 +111,7 @@ spec:
             - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
             - --benchmark=idle
             - -o=idle
+            - --id=$(params.MACHINE_ID)
             command: ["python3.8"]
             env:
             - name: PROM_SERVER
@@ -138,6 +142,8 @@ spec:
           value: $(params.THIRDPARTY_METRICS)
         - name: MODEL_SERVER_IMAGE
           value: $(params.MODEL_SERVER_IMAGE)
+        - name: MACHINE_ID
+          value: $(params.MACHINE_ID)
       taskSpec:
         workspaces:
           - name: mnt
@@ -147,6 +153,7 @@ spec:
             default: stressng
           - name: THIRDPARTY_METRICS
           - name: MODEL_SERVER_IMAGE
+          - name: MACHINE_ID
         steps:
           - name: collect-stressng
             image: $(params.MODEL_SERVER_IMAGE)
@@ -159,6 +166,7 @@ spec:
             - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
             - --benchmark=stressng
             - -o=kepler_query
+            - --id=$(params.MACHINE_ID)
             command: ["python3.8"]
             env:
             - name: PROM_SERVER
@@ -186,6 +194,8 @@ spec:
         value: $(params.ENERGY_SOURCE)
       - name: THIRDPARTY_METRICS
         value: $(params.THIRDPARTY_METRICS)
+      - name: MACHINE_ID
+        value: $(params.MACHINE_ID)
     - name: ibmcloud-s3-push
       runAfter: [train-from-query]
       when:

--- a/model_training/tekton/pipelines/single-retrain.yaml
+++ b/model_training/tekton/pipelines/single-retrain.yaml
@@ -179,6 +179,8 @@ spec:
         value: $(params.TRAINERS)
       - name: THIRDPARTY_METRICS
         value: $(params.THIRDPARTY_METRICS)
+      - name: MACHINE_ID
+        value: $(params.MACHINE_ID)
     - name: train-dynamic-power-model
       when:
         - input: "$(params.OUTPUT_TYPE)"
@@ -206,6 +208,8 @@ spec:
         value: $(params.TRAINERS)
       - name: THIRDPARTY_METRICS
         value: $(params.THIRDPARTY_METRICS)
+      - name: MACHINE_ID
+        value: $(params.MACHINE_ID)
     - name: ibmcloud-s3-push
       runAfter: [train-absolute-power-model, train-dynamic-power-model]
       when:

--- a/model_training/tekton/pipelines/single-train.yaml
+++ b/model_training/tekton/pipelines/single-train.yaml
@@ -89,6 +89,8 @@ spec:
           value: $(params.THIRDPARTY_METRICS)
         - name: MODEL_SERVER_IMAGE
           value: $(params.MODEL_SERVER_IMAGE)
+        - name: MACHINE_ID
+          value: $(params.MACHINE_ID)
       taskSpec:
         workspaces:
           - name: mnt
@@ -97,6 +99,7 @@ spec:
           - name: IDLE_COLLECT_INTERVAL
           - name: THIRDPARTY_METRICS
           - name: MODEL_SERVER_IMAGE
+          - name: MACHINE_ID
         results:
           - name: stress-start-time
             description: The time recorded before running the workload
@@ -116,6 +119,7 @@ spec:
             - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
             - --benchmark=idle
             - -o=idle
+            - --id=$(params.MACHINE_ID)
             command: ["python3.8"]
             env:
             - name: PROM_SERVER
@@ -146,6 +150,8 @@ spec:
           value: $(params.THIRDPARTY_METRICS)
         - name: MODEL_SERVER_IMAGE
           value: $(params.MODEL_SERVER_IMAGE)
+        - name: MACHINE_ID
+          value: $(params.MACHINE_ID)
       taskSpec:
         workspaces:
           - name: mnt
@@ -155,6 +161,7 @@ spec:
             default: stressng
           - name: THIRDPARTY_METRICS
           - name: MODEL_SERVER_IMAGE
+          - name: MACHINE_ID
         steps:
           - name: collect-stressng
             image: $(params.MODEL_SERVER_IMAGE)
@@ -167,6 +174,7 @@ spec:
             - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
             - --benchmark=stressng
             - -o=kepler_query
+            - --id=$(params.MACHINE_ID)
             command: ["python3.8"]
             env:
             - name: PROM_SERVER
@@ -250,6 +258,8 @@ spec:
         value: $(params.TRAINERS)
       - name: THIRDPARTY_METRICS
         value: $(params.THIRDPARTY_METRICS)
+      - name: MACHINE_ID
+        value: $(params.MACHINE_ID)
     - name: train-dynamic-power-model
       when:
         - input: "$(params.OUTPUT_TYPE)"
@@ -277,6 +287,8 @@ spec:
         value: $(params.TRAINERS)
       - name: THIRDPARTY_METRICS
         value: $(params.THIRDPARTY_METRICS)
+      - name: MACHINE_ID
+        value: $(params.MACHINE_ID)
   finally:
     - name: ibmcloud-s3-push
       when:

--- a/model_training/tekton/tasks/original-pipeline-task.yaml
+++ b/model_training/tekton/tasks/original-pipeline-task.yaml
@@ -41,6 +41,8 @@ spec:
   - name: THIRDPARTY_METRICS
     description: Specify list of third party metric to export (required only for ThirdParty feature group)
     default: ""
+  - name: MACHINE_ID
+    description: Specify machine id to identify node_type
   workspaces:
   - name: mnt
     optional: true
@@ -66,3 +68,4 @@ spec:
       - --dyn-trainers=$(params.DYN_TRAINERS)
       - --energy-source=$(params.ENERGY_SOURCE)
       - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
+      - --id=$(params.MACHINE_ID)

--- a/model_training/tekton/tasks/train-task.yaml
+++ b/model_training/tekton/tasks/train-task.yaml
@@ -34,6 +34,9 @@ spec:
   - name: THIRDPARTY_METRICS
     description: Specify list of third party metric to export (required only for ThirdParty feature group)
     default: ""
+  - name: MACHINE_ID
+    description: Specify machine id to identify node_type
+    default: ""
   workspaces:
   - name: mnt
     optional: true
@@ -55,3 +58,4 @@ spec:
       - --output-type=$(params.OUTPUT_TYPE)
       - --trainers=$(params.TRAINERS)
       - --thirdparty-metrics="$(params.THIRDPARTY_METRICS)"
+      - --id=$(params.MACHINE_ID)

--- a/src/server/model_server.py
+++ b/src/server/model_server.py
@@ -12,9 +12,9 @@ util_path = os.path.join(os.path.dirname(__file__), 'util')
 sys.path.append(src_path)
 sys.path.append(util_path)
 
-from util.train_types import get_valid_feature_groups, ModelOutputType, FeatureGroups, FeatureGroup
+from util.train_types import get_valid_feature_groups, ModelOutputType, FeatureGroups, FeatureGroup, weight_support_trainers
 from util.config import getConfig, model_toppath, ERROR_KEY, MODEL_SERVER_MODEL_REQ_PATH, MODEL_SERVER_MODEL_LIST_PATH, initial_pipeline_url, download_path
-from util.loader import parse_filters, is_valid_model, load_json, load_weight, get_model_group_path, get_archived_file, METADATA_FILENAME, CHECKPOINT_FOLDERNAME, get_pipeline_path, any_node_type, is_matched_type, lr_trainers
+from util.loader import parse_filters, is_valid_model, load_json, load_weight, get_model_group_path, get_archived_file, METADATA_FILENAME, CHECKPOINT_FOLDERNAME, get_pipeline_path, any_node_type, is_matched_type
 
 ###############################################
 # model request 
@@ -48,7 +48,7 @@ def select_best_model(valid_groupath, filters, trainer_name="", node_type=any_no
                     and not os.path.isfile(os.path.join(valid_groupath,f)) \
                     and (trainer_name == "" or trainer_name in f)]
     if weight:
-        model_names = [name for name in model_names if name.split("_")[0] in lr_trainers]
+        model_names = [name for name in model_names if name.split("_")[0] in weight_support_trainers]
     # Load metadata of trainers
     best_cadidate = None
     best_response = None

--- a/src/train/__init__.py
+++ b/src/train/__init__.py
@@ -10,12 +10,11 @@ extractor_path = os.path.join(os.path.dirname(__file__), 'extractor')
 sys.path.append(extractor_path)
 isolator_path = os.path.join(os.path.dirname(__file__), 'isolator')
 sys.path.append(isolator_path)
-profiler_path = os.path.join(os.path.dirname(__file__), 'profiler')
-sys.path.append(profiler_path)
 
 from extractor import DefaultExtractor
 from smooth_extractor import SmoothExtractor
-from profiler import Profiler, generate_profiles
+from profiler.profiler import Profiler, generate_profiles
+from profiler.node_type_index import NodeTypeIndexCollection, NodeTypeSpec
 from isolator import MinIdleIsolator, ProfileBackgroundIsolator, NoneIsolator
 from train_isolator import TrainIsolator
 from pipeline import NewPipeline, load_class

--- a/src/train/exporter/exporter.py
+++ b/src/train/exporter/exporter.py
@@ -2,8 +2,6 @@ import os
 import sys
 
 import datetime
-import shutil
-import pandas as pd
 
 util_path = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
 sys.path.append(util_path)
@@ -11,88 +9,55 @@ sys.path.append(util_path)
 cur_path = os.path.join(os.path.dirname(__file__))
 sys.path.append(cur_path)
 
-from validator import find_acceptable_mae
-from train_types import ModelOutputType, PowerSourceMap, FeatureGroup
-from loader import load_csv, load_pipeline_metadata, get_model_group_path, load_metadata, load_train_args, get_preprocess_folder, get_general_filename
-from saver import WEIGHT_FILENAME, save_pipeline_metadata, save_train_args
+from validator import get_validated_export_items, BestModelCollection
+from loader import load_metadata, load_node_type_index, get_version_path, get_export_path
 from format import time_to_str
-from writer import generate_pipeline_page, generate_validation_results, append_version_readme
+from writer import generate_pipeline_page, generate_report_results, generate_pipeline_readme, append_version_readme, get_workload_content
+from config import ERROR_KEY
 
-def export(data_path, pipeline_path, machine_path, machine_id, version, publisher, collect_date, include_raw=False):
+repo_url = "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models"
+
+def export(data_path, pipeline_path, db_path, publisher, collect_date, inputs):
+    # load pipeline metadata
     pipeline_metadata = load_metadata(pipeline_path)
     if pipeline_metadata is None:
         print("no pipeline metadata")
         return
-    
-    pipeline_name = pipeline_metadata["name"]
-    # update pipeline metadata
-    pipeline_metadata["version"] = version
+    # add publish information to pipeline metadata
     pipeline_metadata["publisher"] = publisher
     pipeline_metadata["collect_time"] = time_to_str(collect_date)
     pipeline_metadata["export_time"] = time_to_str(datetime.datetime.utcnow())
 
-    input_path = os.path.join(pipeline_path, "..")
-    out_pipeline_path = os.path.join(machine_path, pipeline_name)
-
-    preprocess_folder = get_preprocess_folder(pipeline_path, assure=False)
-    if include_raw:
-        # copy preprocessed_data
-        if os.path.exists(preprocess_folder):
-            destination_folder = get_preprocess_folder(out_pipeline_path)
-            shutil.copytree(preprocess_folder, destination_folder, dirs_exist_ok=True)
-        else:
-            print("cannot export raw data: {} does not exist.", preprocess_folder)
-        
-    extractor = pipeline_metadata["extractor"]
-    isolator = pipeline_metadata["isolator"]
-    mae_validated_df_map = dict()
-    for energy_source in PowerSourceMap.keys():
-        mae_validated_df_map[energy_source] = dict()
-        for ot in ModelOutputType:
-            metadata_df = load_pipeline_metadata(pipeline_path, energy_source, ot.name)
-            if metadata_df is None:
-                print("no metadata for ", energy_source, ot.name)
-                continue
-            mae_validated_list = [] 
-            for _, row in metadata_df.iterrows():
-                model_name = row["model_name"]
-                fg = FeatureGroup[row["feature_group"]]
-                preprocess_filename = get_general_filename("preprocess", energy_source, fg, ot, extractor, isolator)
-                preprocess_data = load_csv(preprocess_folder, preprocess_filename)
-                is_acceptable, power_range, mae_threshold = find_acceptable_mae(preprocess_data, row)
-                if is_acceptable:
-                    mae_validated_list += [row.to_dict()]
-                    out_group_path = get_model_group_path(machine_path, ot, fg, energy_source, assure=True, pipeline_name=pipeline_name)
-                    in_group_path = get_model_group_path(input_path, ot, fg, energy_source, assure=False, pipeline_name=pipeline_name)
-                    out_model_path = os.path.join(out_group_path, model_name)
-                    in_model_path = os.path.join(in_group_path, model_name)
-                    # copy zip file
-                    shutil.copy(in_model_path + ".zip", out_model_path + ".zip")
-                    # copy weight if exists
-                    weight_filename = WEIGHT_FILENAME + ".json"
-                    if weight_filename in os.listdir(in_model_path):
-                        shutil.copy(os.path.join(in_model_path, weight_filename), out_model_path + ".json")
-            mae_validated_df = pd.DataFrame(mae_validated_list)
-            if len(mae_validated_df) > 0:
-                mae_validated_df["power_range"] = power_range
-                mae_validated_df["mae_threshold"] = mae_threshold
-                # save pipeline metadata 
-                save_pipeline_metadata(out_pipeline_path, pipeline_metadata, energy_source, ot.name, mae_validated_df)
-                print("Exported models for {}/{}".format(energy_source, ot.name))
-                print(mae_validated_df)
-                mae_validated_df_map[energy_source][ot.name] = mae_validated_df
-            else:
-                print("No valid models exported for {}/{}".format(energy_source, ot.name))
-
-    train_args = load_train_args(pipeline_path)
-    train_args["machine_id"] = machine_id
-
-    # save train args
-    save_train_args(out_pipeline_path, train_args)
-
-    # generate document
-    generate_pipeline_page(data_path, machine_path, train_args)
-    generate_validation_results(out_pipeline_path, train_args, mae_validated_df_map)
-    append_version_readme(machine_path, train_args, pipeline_metadata, include_raw)
-
-
+    node_type_index_json = load_node_type_index(pipeline_path)
+    if node_type_index_json is None:
+        print("no node type index")
+        return
+    node_types = node_type_index_json.keys()
+    best_model_collections = dict()
+    for node_type in node_types:
+        best_model_collections[int(node_type)] = BestModelCollection(ERROR_KEY)
+    
+    # get path
+    pipeline_name = pipeline_metadata["name"]
+    local_export_path = get_export_path(db_path, pipeline_name)
+    local_version_path = get_version_path(db_path)
+    remote_version_path = get_version_path(repo_url, assure=False)
+   
+    # get validated export items (models)
+    export_items = get_validated_export_items(pipeline_path, pipeline_name)
+    
+    for export_item in export_items:
+        # export models
+        export_item.export(local_version_path)
+        # update best model
+        best_model_collections[export_item.node_type].compare_new_item(export_item)
+    
+    # generate pipeline page
+    workload_content = workload_content = get_workload_content(data_path, inputs)
+    generate_pipeline_page(local_version_path, pipeline_metadata, workload_content)
+    # generate error report page
+    generate_report_results(local_export_path, best_model_collections, node_type_index_json, remote_version_path)
+    # generate validation result page
+    generate_pipeline_readme(pipeline_name, local_export_path, node_type_index_json, best_model_collections)
+    # add new pipeline item to version path
+    append_version_readme(local_version_path, pipeline_metadata)

--- a/src/train/exporter/validator.py
+++ b/src/train/exporter/validator.py
@@ -1,16 +1,108 @@
 import os
 import sys
+import pandas as pd
+import shutil
 
 util_path = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
 sys.path.append(util_path)
 
-from loader import load_train_args
-from config import ERROR_KEY
+cur_path = os.path.join(os.path.dirname(__file__))
+sys.path.append(cur_path)
 
-default_threshold_percent = 20
+from train_types import ModelOutputType, PowerSourceMap, FeatureGroup, weight_support_trainers
+from loader import load_pipeline_metadata, get_model_group_path, load_weight, get_archived_file
+from saver import save_json
+
+mae_threshold = 10
+mape_threshold = 20
+
+class ExportModel():
+    def __init__(self, models_path, output_type, feature_group, energy_source, pipeline_name, model_name, metadata):
+        self.pipeline_name = pipeline_name
+        self.energy_source = energy_source
+        self.output_type = output_type
+        self.feature_group = feature_group
+        self.model_name = model_name
+        self.source_model_group_path = get_model_group_path(models_path, output_type, feature_group, energy_source, assure=False, pipeline_name=pipeline_name)
+        self.source_model_path = os.path.join(self.source_model_group_path, self.model_name)
+        self.source_model_zip = get_archived_file(self.source_model_group_path, self.model_name)
+        self.metadata = metadata
+        self.node_type = metadata["node_type"]
+        trainer = metadata["trainer"]
+        self.weight = None
+        if trainer in weight_support_trainers:
+            self.weight = load_weight(self.source_model_path)
+
+    # assure if version_path is local
+    def get_export_path(self, version_path, assure):
+        target_model_path =  get_model_group_path(version_path, self.output_type, self.feature_group, self.energy_source, assure=assure, pipeline_name=self.pipeline_name)
+        return target_model_path
+
+    def export(self, local_version_path):
+        target_model_group_path = self.get_export_path(local_version_path, assure=True)
+        if self.weight is not None:
+            save_json(path=target_model_group_path, name=self.model_name, data=self.weight)   
+        target_model_zip = get_archived_file(target_model_group_path, self.model_name)
+        shutil.copy(self.source_model_zip, target_model_zip)
+
+    def get_weight_filepath(self, version_path):
+        return os.path.join(self.get_export_path(version_path, assure=False), self.model_name + ".json")
     
-def find_acceptable_mae(preprocess_data, metadata):
-    power_cols = [col for col in preprocess_data.columns if "power" in col]
-    power_range = preprocess_data[power_cols].max() - preprocess_data[power_cols].min()
-    mae_threshold = default_threshold_percent * power_range.max() / 100
-    return metadata[ERROR_KEY] <= mae_threshold, power_range.max(), mae_threshold
+    def get_archived_filepath(self, version_path):
+        return get_archived_file(self.get_export_path(version_path, assure=False), self.model_name)
+
+
+class BestModelCollection():
+    def __init__(self, error_key):
+        self.error_key = error_key
+        self.collection = dict()
+        self.weight_collection = dict()
+        for energy_source in PowerSourceMap.keys():
+            self.collection[energy_source] = dict()
+            self.weight_collection[energy_source] = dict()
+            for ot in ModelOutputType:
+                self.collection[energy_source][ot.name] = dict()
+                self.weight_collection[energy_source][ot.name] = dict()
+                for fg in FeatureGroup:
+                    self.collection[energy_source][ot.name][fg.name] = None
+                    self.weight_collection[energy_source][ot.name][fg.name] = None
+        self.has_model = False
+
+    def compare_new_item(self, export_item):
+        current_best = self.collection[export_item.energy_source][export_item.output_type.name][export_item.feature_group.name] 
+        compare_mape = export_item.metadata[self.error_key]
+        if current_best is None or current_best.metadata[self.error_key] > compare_mape:
+            self.collection[export_item.energy_source][export_item.output_type.name][export_item.feature_group.name] = export_item
+            self.has_model = True
+        if export_item.weight is not None:
+            current_best = self.weight_collection[export_item.energy_source][export_item.output_type.name][export_item.feature_group.name] 
+            if current_best is None or current_best.metadata[self.error_key] > compare_mape:
+                self.weight_collection[export_item.energy_source][export_item.output_type.name][export_item.feature_group.name] = export_item
+        
+    def get_best_item(self, energy_source, output_type_name, feature_group_name):
+        return self.collection[energy_source][output_type_name][feature_group_name]
+    
+    def get_best_item_with_weight(self, energy_source, output_type_name, feature_group_name):
+        return self.weight_collection[energy_source][output_type_name][feature_group_name]
+
+# get_validated_export_items return valid export items
+def get_validated_export_items(pipeline_path, pipeline_name):
+    export_items = []
+    models_path = os.path.join(pipeline_path, "..")
+    for energy_source in PowerSourceMap.keys():
+        for ot in ModelOutputType:
+            metadata_df = load_pipeline_metadata(pipeline_path, energy_source, ot.name)
+            if metadata_df is None:
+                print("no metadata for", energy_source, ot.name)
+                continue
+            for _, row in metadata_df.iterrows():
+                if row['mape'] <= mape_threshold or row['mae'] <= mae_threshold:
+                    model_name = row["model_name"]
+                    fg = FeatureGroup[row["feature_group"]]
+                    export_item = ExportModel(models_path, ot, fg, energy_source, pipeline_name, model_name, row.to_dict())
+                    source_file = export_item.source_model_zip
+                    if not os.path.exists(source_file):
+                        print("source not exist: ", source_file)
+                        continue
+                    export_items += [export_item]
+    return export_items

--- a/src/train/extractor/extractor.py
+++ b/src/train/extractor/extractor.py
@@ -121,7 +121,8 @@ class DefaultExtractor(Extractor):
         if node_info_data is not None:
             feature_power_data = feature_power_data.join(node_info_data)
         if node_info_column not in feature_power_data.columns:
-            feature_power_data[node_info_column] = int(default_node_type)
+            feature_power_data[node_info_column] = default_node_type
+        feature_power_data[node_info_column] = feature_power_data[node_info_column].astype(int)
         
         # 6. validate input with correlation
         corr = find_correlations(energy_source, feature_power_data, power_columns, workload_features)

--- a/src/train/offline_trainer.py
+++ b/src/train/offline_trainer.py
@@ -22,8 +22,6 @@ prom_path = os.path.join(os.path.dirname(__file__), 'prom')
 sys.path.append(prom_path)
 extractor_path = os.path.join(os.path.dirname(__file__), 'extractor')
 sys.path.append(extractor_path)
-profiler_path = os.path.join(os.path.dirname(__file__), 'profiler')
-sys.path.append(profiler_path)
 isolator_path = os.path.join(os.path.dirname(__file__), 'isolator')
 sys.path.append(isolator_path)
 
@@ -31,7 +29,7 @@ from config import model_toppath
 from loader import get_pipeline_path, DEFAULT_PIPELINE
 from train_types import PowerSourceMap
 from prom_types import get_valid_feature_group_from_queries, prom_responses_to_results
-from profiler import Profiler, generate_profiles
+from profiler.profiler import Profiler, generate_profiles
 from extractor import DefaultExtractor
 from isolator import ProfileBackgroundIsolator
 from train_isolator import TrainIsolator

--- a/src/train/online_trainer.py
+++ b/src/train/online_trainer.py
@@ -9,8 +9,6 @@ prom_path = os.path.join(os.path.dirname(__file__), 'prom')
 sys.path.append(prom_path)
 extractor_path = os.path.join(os.path.dirname(__file__), 'extractor')
 sys.path.append(extractor_path)
-profiler_path = os.path.join(os.path.dirname(__file__), 'profiler')
-sys.path.append(profiler_path)
 isolator_path = os.path.join(os.path.dirname(__file__), 'isolator')
 sys.path.append(isolator_path)
 
@@ -27,7 +25,7 @@ from train_types import PowerSourceMap, FeatureGroups
 from pipeline import NewPipeline
 from extractor import DefaultExtractor
 from isolator import MinIdleIsolator, ProfileBackgroundIsolator
-from profiler import load_all_profiles
+from profiler.profiler import load_all_profiles
 
 
 default_trainers = ['GradientBoostingRegressorTrainer']

--- a/src/train/profiler/node_type_index.py
+++ b/src/train/profiler/node_type_index.py
@@ -1,0 +1,185 @@
+# NodeTypeIndexCollection manages node_type index under pipeline path
+#p
+# Usage:
+#   index_collection = NodeTypeIndexCollection(pipeline_path)
+#   node_type = index_collection.index_train_machine(processor, cores, chips, cache_kb, memory_gb, cpu_freq_mhz, power_mgt, minmax_watt)
+#   index_collection.save()
+
+import sys
+import os
+
+util_path = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
+sys.path.append(util_path)
+
+from saver import save_node_type_index, save_machine_spec
+from loader import load_node_type_index
+
+import enum
+
+import re
+def rename(name):
+    name = name.replace("(R)", "")
+    name = name.replace("(r)", "")
+    name = name.replace("CPU", "")
+    name = name.replace("Processor", "")
+    name = name.replace("processor", "")
+    name = re.sub("\d+-Bit Multi-Core", '', name)
+    name = name.split("(")[0].strip()
+    name = name.split("[")[0].strip()
+    name = name.replace("@", "")
+    name = name.replace("®", "")
+    name = name.replace(",", "")
+    name = re.sub('\d+(\.\d+)?\s?[G|M|g|m][H|h]z', '', name).strip()
+    return name
+
+def format_processor(processor):
+    return "_".join(re.sub(r'\(.*\)', '', rename(processor)).split()).replace("-", "_").replace("V", "v").replace("_v", "v")
+
+GB = 1024*1024*1024
+import psutil
+import cpuinfo
+def generate_spec(data_path, machine_id):
+    processor = "unknown"
+    cpu_info = cpuinfo.get_cpu_info()
+    if "brand_raw" in cpu_info:
+        processor = format_processor(cpu_info["brand_raw"])
+    cores = psutil.cpu_count(logical=True)
+    chips = psutil.cpu_count(logical=False)
+    memory = psutil.virtual_memory().total
+    memory_gb = int(memory/GB)
+    cpu_freq_mhz = round(psutil.cpu_freq(percpu=False).max/100)*100 # round to one decimal of GHz
+    spec_values = {
+        "processor": processor,
+        "cores": cores,
+        "chips": chips,
+        "memory_gb": memory_gb,
+        "cpu_freq_mhz": cpu_freq_mhz
+    }
+    spec = NodeTypeSpec(**spec_values)
+    print("Save machine spec ({}): ".format(data_path))
+    print(str(spec))
+    save_machine_spec(data_path, machine_id, spec)
+
+class NodeAttribute(str, enum.Enum):
+    PROCESSOR = "processor"
+    CORES = "cores"
+    CHIPS = "chips"
+    MEMORY = "memory"
+    FREQ = "frequency"
+        
+def load_node_type_spec(node_type_index_json):
+    node_type_spec_index = dict()
+    if node_type_index_json is not None:
+        for index, spec_obj in node_type_index_json.items():
+            spec = NodeTypeSpec()
+            spec.load(spec_obj)
+            node_type_spec_index[int(index)] = spec
+    return node_type_spec_index
+
+no_data = None
+
+# NodeTypeSpec defines spec of each node_type index
+class NodeTypeSpec():
+    def __init__(self, **kwargs):
+        self.attrs = dict()        
+        self.attrs[NodeAttribute.PROCESSOR] = kwargs.get('processor', no_data)
+        self.attrs[NodeAttribute.CORES] = kwargs.get('cores', no_data)
+        self.attrs[NodeAttribute.CHIPS] = kwargs.get('chips', no_data)
+        self.attrs[NodeAttribute.MEMORY] = kwargs.get('memory_gb', no_data)
+        self.attrs[NodeAttribute.FREQ] = kwargs.get('cpu_freq_mhz', no_data)
+        self.members = []
+        
+    def load(self, json_obj):
+        for attr, attr_values in json_obj["attrs"].items():
+            self.attrs[attr] = attr_values
+        self.members = json_obj["members"]
+        
+    def add_member(self, machine_id):
+        if machine_id in self.members:
+            print("member already exists: ", machine_id)
+            return True
+        self.members += [machine_id]
+        return True    
+
+    def get_size(self):
+        return len(self.members)
+    
+    # check the comparing node-type spec is covered by this node-type spec
+    def cover(self, compare_spec):
+        if not isinstance(compare_spec, NodeTypeSpec):
+            return False
+        for attr in NodeAttribute:
+            if compare_spec.attrs[attr] is not None and str(self.attrs[attr]) != str(compare_spec.attrs[attr]):
+                return False
+        return True
+
+    def __str__(self):
+        out_str = ""
+        for attr in NodeAttribute:
+            out_str += "{} ({})\n".format(attr, str(self.attrs[attr]))
+        return out_str
+    
+    def get_json(self):
+        json_obj = dict()
+        json_obj["attrs"] = dict()
+        for attr in NodeAttribute:
+            json_obj["attrs"]["{}".format(attr)] = self.attrs[attr]
+        json_obj["members"] = self.members
+        return json_obj
+    
+    def complete_info(self):
+        for attr in NodeAttribute:
+            if self.attrs[attr] is None:
+                return False
+        return True
+    
+    def copy(self):
+        spec = NodeTypeSpec()
+        spec.attrs = self.attrs.copy()
+        spec.members = self.members.copy()
+        return spec
+        
+    
+class NodeTypeIndexCollection():
+    def __init__(self, pipeline_path):
+        self.pipeline_path = pipeline_path
+        node_type_index_json = load_node_type_index(self.pipeline_path)
+        self.node_type_index = load_node_type_spec(node_type_index_json)
+
+    def index_train_machine(self, machine_id, new_spec):
+        if not new_spec.complete_info():
+            print("Machine info not completed: ", str(new_spec))
+            return -1
+        covered_index = self.get_node_type(new_spec)
+        if covered_index == -1:
+            covered_index = 0
+            if len(self.node_type_index.keys()) > 0:
+                covered_index = max(self.node_type_index.keys()) + 1
+            self.node_type_index[covered_index] = new_spec
+        self.node_type_index[covered_index].add_member(machine_id)
+        return covered_index
+
+    def get_node_type(self, compare_spec):
+        if len(self.node_type_index) == 0:
+            return -1
+        for index, node_type_spec in self.node_type_index.items():
+            if node_type_spec.cover(compare_spec):
+                return index
+        return -1
+    
+    def get_json(self):
+        json_obj = dict()
+        for index, node_type_spec in self.node_type_index.items():
+            json_obj[index] = node_type_spec.get_json()
+        return json_obj
+    
+    def save(self):
+        obj = self.get_json()
+        save_node_type_index(self.pipeline_path, obj)
+
+    def copy(self):
+        node_collection = NodeTypeIndexCollection(self.pipeline_path)
+        removed_items = [node_type for node_type in node_collection.node_type_index.keys() if node_type not in self.node_type_index.keys()]
+        for node_type in removed_items:
+            del node_collection.node_type_index[node_type]
+        return node_collection

--- a/src/train/profiler/profiler.py
+++ b/src/train/profiler/profiler.py
@@ -81,7 +81,7 @@ class Profiler():
     def __init__(self, extractor):
         self.extractor = extractor
 
-    def process(self, query_results, profile_top_path=default_profile_top_path, save=True):
+    def process(self, query_results, profile_top_path=default_profile_top_path, save=True, replace_node_type=default_node_type):
         profile_path =prepare_profile_path(profile_top_path)
 
         node_types, node_info_data = self.extractor.get_node_types(query_results)
@@ -94,13 +94,13 @@ class Profiler():
              #######################
             profile = dict()
             if node_types is None:
-                node_types = [default_node_type]
+                node_types = [replace_node_type]
             for node_type in node_types:
                 power_data= self.extractor.get_power_data(query_results, energy_components, source)
                 if node_info_data is not None:
                     power_data = power_data.join(node_info_data)
                 else:
-                    power_data[node_info_column] = default_node_type
+                    power_data[node_info_column] = replace_node_type
                 power_labels = power_data.columns
                 for component in energy_components:
                     power_label = component_to_col(component) 

--- a/src/train/trainer/LogarithmicRegressionTrainer/main.py
+++ b/src/train/trainer/LogarithmicRegressionTrainer/main.py
@@ -10,12 +10,11 @@ import numpy as np
 def p0_func(x, y):
     print(y.max(), y.min())
     a = y.max()-y.min()
-    b = 1
-    c = y.min()
-    return [a, b, c]
+    b = y.min()
+    return [a, b]
 
-def log_func(x, a, b, c):
-    y = [a * np.log(b*xi) + c if b*xi > 0 and a * np.log(b*xi) > 0 else c for xi in x]
+def log_func(x, a, b):
+    y = [a * np.log(xi) + b if xi > 0 else 0 for xi in x]
     return y
 
 class LogarithmicRegressionTrainer(CurveFitTrainer):

--- a/src/train/trainer/XGBoostTrainer/main.py
+++ b/src/train/trainer/XGBoostTrainer/main.py
@@ -17,8 +17,7 @@ sys.path.append(train_path)
 sys.path.append(prom_path)
 sys.path.append(util_path)
 
-from train_types import FeatureGroup, FeatureGroups, EnergyComponentLabelGroups, EnergyComponentLabelGroup, ModelOutputType, XGBoostMissingModelXOrModelDescException, XGBoostModelFeatureOrLabelIncompatabilityException, XGBoostRegressionTrainType
-from prom.query import PrometheusClient
+from train_types import FeatureGroup, FeatureGroups, EnergyComponentLabelGroups, EnergyComponentLabelGroup, XGBoostMissingModelXOrModelDescException, XGBoostModelFeatureOrLabelIncompatabilityException, XGBoostRegressionTrainType
 from extractor.extractor import DefaultExtractor
 
 

--- a/src/train/trainer/__init__.py
+++ b/src/train/trainer/__init__.py
@@ -130,34 +130,39 @@ class Trainer(metaclass=ABCMeta):
 
     def process(self, data, power_labels, pipeline_lock):
         node_types = pd.unique(data[node_info_column])
-        for node_type in node_types:
-            node_type = int(node_types)
-            save_path = self._get_save_path(node_type)
-            self.node_scalers[node_type] = load_scaler(save_path)
-            self.load_model(node_type)
-            node_type_filtered_data = data[data[node_info_column] == node_type]
-            if self.node_scalers[node_type] is None:
-                self.print_log("fit scaler to latest data {1} for node_type={0}".format(node_type, self.feature_group_name))
-                # no profiled scaler
-                x_values = node_type_filtered_data[self.features].values
-                self.node_scalers[node_type] = MaxAbsScaler()
-                self.node_scalers[node_type].fit(x_values)
-            
-            X_test_map = dict()
-            y_test_map = dict()
-            for component in self.energy_components:
-                X_values, y_values = self.apply_ratio(component, node_type_filtered_data, power_labels)
-                X_train, X_test, y_train, y_test = normalize_and_split(X_values, y_values, scaler=self.node_scalers[node_type])
-                X_test_map[component] = X_test
-                y_test_map[component] = y_test
-                self.train(node_type, component, X_train, y_train)
-                self.save_checkpoint(self.node_models[node_type][component], self._checkpoint_filepath(component, node_type))
-            if self.should_archive(node_type):
-                pipeline_lock.acquire()
-                try:
-                    self.save_model_and_metadata(node_type, X_test_map, y_test_map)
-                finally:
-                    pipeline_lock.release()
+        try:
+            for node_type in node_types:
+                node_type = int(node_type)
+                save_path = self._get_save_path(str(node_type))
+                self.node_scalers[node_type] = load_scaler(save_path)
+                self.load_model(node_type)
+                
+                node_type_filtered_data = data[data[node_info_column] == node_type]
+                if self.node_scalers[node_type] is None:
+                    self.print_log("fit scaler to latest data {1} for node_type={0}".format(node_type, self.feature_group_name))
+                    # no profiled scaler
+                    x_values = node_type_filtered_data[self.features].values
+                    self.node_scalers[node_type] = MaxAbsScaler()
+                    self.node_scalers[node_type].fit(x_values)
+                
+                X_test_map = dict()
+                y_test_map = dict()
+                for component in self.energy_components:
+                    X_values, y_values = self.apply_ratio(component, node_type_filtered_data, power_labels)
+                    X_train, X_test, y_train, y_test = normalize_and_split(X_values, y_values, scaler=self.node_scalers[node_type])
+                    X_test_map[component] = X_test
+                    y_test_map[component] = y_test
+                    self.train(node_type, component, X_train, y_train)
+                    self.save_checkpoint(self.node_models[node_type][component], self._checkpoint_filepath(component, node_type))
+                if self.should_archive(node_type):
+                    pipeline_lock.acquire()
+                    try:
+                        self.save_model_and_metadata(node_type, X_test_map, y_test_map)
+                    finally:
+                        pipeline_lock.release()
+        except Exception as e:
+            print(e)
+            pipeline_lock.release()
 
     def apply_ratio(self, component, node_type_filtered_data, power_labels):
         power_label = component_to_col(component) 

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -4,7 +4,7 @@ cur_path = os.path.join(os.path.dirname(__file__), '.')
 sys.path.append(cur_path)
 
 # commonly-used definitions
-from loader import load_json, load_csv, load_pkl, load_metadata, load_scaler, load_weight, load_remote_pkl, list_model_names, DEFAULT_PIPELINE, class_to_json
+from loader import load_json, load_csv, load_pkl, load_metadata, load_scaler, load_weight, load_remote_pkl, list_model_names, DEFAULT_PIPELINE, class_to_json, version
 from saver import assure_path, save_csv, save_json, save_pkl, save_metadata, save_scaler, save_weight
 from config import getConfig, model_toppath
 from prom_types import get_valid_feature_group_from_queries

--- a/src/util/format.py
+++ b/src/util/format.py
@@ -19,5 +19,8 @@ def print_bounded_multiline_message(input_lines, maxlength=200):
     
     print(border)
 
+from datetime import datetime
 def time_to_str(time):
-    return time.strftime("%Y-%m-%d %H:%M:%S")
+    if isinstance(time, datetime):
+        return time.strftime("%Y-%m-%d %H:%M:%S")
+    return time

--- a/src/util/prom_types.py
+++ b/src/util/prom_types.py
@@ -35,7 +35,7 @@ node_query_suffix = "joules_total"
 
 usage_ratio_query = "kepler_container_cpu_usage_per_package_ratio"
 # mostly available
-valid_container_query = "kepler_container_kubelet_cpu_usage_total"
+valid_container_query = "kepler_container_bpf_cpu_time_us_total"
 node_info_query = "kepler_node_node_info"
 cpu_frequency_info_query = "kepler_node_cpu_scaling_frequency_hertz"
 

--- a/src/util/saver.py
+++ b/src/util/saver.py
@@ -6,6 +6,9 @@ METADATA_FILENAME = 'metadata'
 SCALER_FILENAME = 'scaler'
 WEIGHT_FILENAME = 'weight'
 TRAIN_ARGS_FILENAME = 'train_arguments'
+NODE_TYPE_INDEX_FILENAME = 'node_type_index'
+
+MACHINE_SPEC_PATH = "machine_spec"
 
 def _pipeline_model_metadata_filename(energy_source, model_type):
     return "{}_{}_model_metadata".format(energy_source, model_type)
@@ -41,6 +44,14 @@ def save_csv(path, name, data):
     filename = os.path.join(path, name)   
     data.to_csv(filename)
     return name
+
+def save_machine_spec(data_path, machine_id, spec):
+    machine_spec_path = os.path.join(data_path, MACHINE_SPEC_PATH)
+    assure_path(machine_spec_path)
+    save_json(machine_spec_path, machine_id, spec.get_json())
+
+def save_node_type_index(pipeline_path, node_type_index):
+    return save_json(pipeline_path, NODE_TYPE_INDEX_FILENAME, node_type_index)
 
 def save_metadata(model_path, metadata):
     return save_json(model_path, METADATA_FILENAME, metadata)

--- a/src/util/train_types.py
+++ b/src/util/train_types.py
@@ -37,6 +37,12 @@ CATEGORICAL_LABEL_TO_VOCAB = {
                     "cpu_scaling_frequency_hertz": ["1GHz", "2GHz", "3GHz"],
                     }
 
+no_weight_trainers = ['PolynomialRegressionTrainer', 'GradientBoostingRegressorTrainer', 'KNeighborsRegressorTrainer', 'LinearRegressionTrainer','SVRRegressorTrainer', 'XgboostFitTrainer']
+weight_support_trainers = ['SGDRegressorTrainer', 'LogarithmicRegressionTrainer', 'LogisticRegressionTrainer', 'ExponentialRegressionTrainer']
+default_trainer_names = no_weight_trainers + weight_support_trainers
+default_trainers = ",".join(default_trainer_names)
+
+
 class FeatureGroup(enum.Enum):
     Full = 1
     WorkloadOnly = 2

--- a/tests/model_tester.py
+++ b/tests/model_tester.py
@@ -27,6 +27,7 @@ from train_types import ModelOutputType, PowerSourceMap
 from train.isolator.train_isolator import get_background_containers, isolate_container
 from offline_trainer_test import get_pipeline_name, isolators, offline_trainer_output_path
 from estimator.load import load_model
+from loader import default_node_type
 
 from prom_types import prom_responses_to_results, TIMESTAMP_COL
 
@@ -51,9 +52,9 @@ def process(train_dataset_name, test_dataset_name, target_path):
     test_data = prom_responses_to_results()
     node_types, _ = extractor.get_node_types(idle_data)
     if node_types is None:
-        node_type = "1" # default node type
+        node_type = default_node_type # default node type
     else:
-        node_type = node_types[0] # limit only one node type in single data set
+        node_type = int(node_types[0]) # limit only one node type in single data set
 
     # find best_ab
     best_abs_model = find_best_abs_model()

--- a/tests/trainer_test.py
+++ b/tests/trainer_test.py
@@ -14,6 +14,7 @@ sys.path.append(src_path)
 from train import load_class
 from util import PowerSourceMap
 from util.loader import DEFAULT_PIPELINE
+from util.train_types import default_trainer_names
 
 from isolator_test import test_isolators, get_isolate_results
 from extractor_test import test_extractors, get_extract_results, test_energy_source, get_expected_power_columns, node_info_column
@@ -21,7 +22,7 @@ from extractor_test import test_extractors, get_extract_results, test_energy_sou
 import pandas as pd
 import threading
 
-test_trainer_names = [ 'PolynomialRegressionTrainer', 'GradientBoostingRegressorTrainer', 'SGDRegressorTrainer', 'KNeighborsRegressorTrainer', 'LinearRegressionTrainer','SVRRegressorTrainer', 'XgboostFitTrainer', 'LogarithmicRegressionTrainer', 'LogisticRegressionTrainer', 'ExponentialRegressionTrainer']
+test_trainer_names = default_trainer_names
 pipeline_lock = threading.Lock()
 
 def assert_train(trainer, data, energy_components):


### PR DESCRIPTION
This PR is related to the issue https://github.com/sustainable-computing-io/kepler-model-server/issues/216 and TODO list in previous PR https://github.com/sustainable-computing-io/kepler-model-server/pull/222.

The main change is to add node_type indexing in `src/train/profiler/node_type_index.py`. 
I introduce NodeTypeSpec, NodeTypeIndexCollection to group inputting machine data by spec on each pipeline training. 
As shown below, at collection, we will autogenerate NodeTypeSpec (processor, #cores, #chips, memory and so on) and keep it in data path. At training, we will read that value by the machine id and then index it in the NodeTypeIndexCollection. 
If the same spec has been indexed, it will use the same index number. However, we expect a step to append data from the same group before training. For AWS instance, we expect single profile per one index. The machine index will be kept under pipeline folder in Json format (node_type_index.json). We can read this file and generate machine index on export.

![node_type_index](https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/ac428509-55e1-452f-8e81-a163505a645a)

In addition to above enhancement, this PR also includes multiple bug fixes on CI workflow including adding complete-train pipeline run on tekton test.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
