### PR TITLE
fix pipeline bug and workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,16 +1,13 @@
 name: Integration Test
 on:
   workflow_call:
-    secrets:
-      docker_username:
-        description: 'Docker username'
-        required: false
-      docker_password:
-        description: 'Docker password'
-        required: false
     inputs:
       base_change:
         description: 'Change flag on base image'
+        required: true
+        type: string
+      docker_secret:
+        description: 'Secret check'
         required: true
         type: string
       image_repo:
@@ -28,6 +25,7 @@ env:
 
 jobs:
   run-integration:
+    if: ${{ (inputs.base_change != 'true') || ( (inputs.base_change == 'true') && (inputs.docker_secret == 'true') ) }}
     runs-on: ubuntu-20.04
     steps:
       - name: use Kepler action to deploy cluster
@@ -42,25 +40,18 @@ jobs:
           kind load docker-image quay.io/sustainable_computing_io/kepler:latest
       - name: checkout
         uses: actions/checkout@v4
-      - name: Login to Docker
-        if: ${{ inputs.base_change == 'true' }} 
-        uses: docker/login-action@v3
-        with:
-            registry: ${{ inputs.image_repo }}
-            username: ${{ secrets.docker_username }}
-            password: ${{ secrets.docker_password }} 
-      - name: Replace value in Dockerfile
-        if: ${{ inputs.base_change == 'true' }} 
-        run: |
-          sed -i "s|quay.io/sustainable_computing_io/kepler_model_server_base:v0.7|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile
-      - name: Replace value in Dockerfile.test
-        if: ${{ inputs.base_change == 'true' }} 
-        run: |
-          sed -i "s|quay.io/sustainable_computing_io/kepler_model_server_base:v0.7|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile.test
       - name: set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Replace value in Dockerfile if base changes
+        if: ${{ (inputs.base_change == 'true') && (inputs.docker_secret == 'true') }}
+        run: |
+          sed -i "s|quay.io/sustainable_computing_io/kepler_model_server_base:v0.7|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile
+      - name: Replace value in Dockerfile.test if base changes
+        if: ${{ (inputs.base_change == 'true') && (inputs.docker_secret == 'true') }}
+        run: |
+          sed -i "s|quay.io/sustainable_computing_io/kepler_model_server_base:v0.7|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile.test
       - name: build Kepler model server and test image and push to local registry
         run: make build build-test push push-test
       - name: set up Kustomize

--- a/.github/workflows/push-pr.yml
+++ b/.github/workflows/push-pr.yml
@@ -153,28 +153,22 @@ jobs:
           echo "change=true" >> "$GITHUB_OUTPUT"
 
   tekton-test:
-    needs: [check-branch, base-image]
-    # the changed base-image has been pushed or no change
-    if: ${{ needs.base-image.outputs.change == 'true' || needs.check-change.outputs.base != 'true' }}
+    needs: [check-secret, check-branch, base-image]
+    if: always()
     uses: ./.github/workflows/tekton-test.yml
     with:
-      base_change: ${{ needs.base-image.outputs.change }}
+      base_change: ${{ needs.check-change.outputs.base }}
+      docker_secret: ${{ needs.check-secret.outputs.docker-secret }}
       image_repo: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
       image_tag: ${{ needs.check-branch.outputs.tag }}
       pipeline_name: std_v0.7
-    secrets:
-      docker_username: ${{ secrets.BOT_NAME }}
-      docker_password: ${{ secrets.BOT_TOKEN }}
 
   integration-test:
-    needs: [check-branch, base-image]
-    # the changed base-image has been pushed or no change
-    if: ${{ needs.base-image.outputs.change == 'true' || needs.check-change.outputs.base != 'true' }}
+    needs: [check-secret, check-branch, base-image]
+    if: always()
     uses: ./.github/workflows/integration-test.yml
     with:
-      base_change: ${{ needs.base-image.outputs.change }}
+      base_change: ${{ needs.check-change.outputs.base }}
+      docker_secret: ${{ needs.check-secret.outputs.docker-secret }}
       image_repo: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
       image_tag: ${{ needs.check-branch.outputs.tag }}
-    secrets:
-      docker_username: ${{ secrets.BOT_NAME }}
-      docker_password: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/tekton-test.yml
+++ b/.github/workflows/tekton-test.yml
@@ -2,16 +2,13 @@ name: Tekton Test
 
 on:
   workflow_call:
-    secrets:
-      docker_username:
-        description: 'Docker username'
-        required: false
-      docker_password:
-        description: 'Docker password'
-        required: false
     inputs:
       base_change:
         description: 'Change flag on base image'
+        required: true
+        type: string
+      docker_secret:
+        description: 'Secret check'
         required: true
         type: string
       image_repo:
@@ -43,6 +40,7 @@ env:
 
 jobs:
   tekton-test:
+    if: ${{ (inputs.base_change != 'true') || ( (inputs.base_change == 'true') && (inputs.docker_secret == 'true') ) }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -51,22 +49,13 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker
-        if: ${{ inputs.base_change == 'true' }} 
-        uses: docker/login-action@v3
-        with:
-            registry: ${{ inputs.image_repo }}
-            username: ${{ secrets.docker_username }}
-            password: ${{ secrets.docker_password }} 
-      - name: Replace value in file
-        if: ${{ inputs.base_change == 'true' }} 
+      - name: Replace value in file if base changes
+        if: ${{ (inputs.base_change == 'true') && (inputs.docker_secret == 'true') }} 
         run: |
           sed -i "s|quay.io/sustainable_computing_io/kepler_model_server_base:v0.7|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile
-
       - name: Build image
         run: |
           docker build -t $IMAGE -f dockerfiles/Dockerfile .
-
       - name: Prepare Cluster
         working-directory: model_training
         run: |
@@ -135,7 +124,7 @@ jobs:
             - name: STRESS_BREAK_INTERVAL
               value: 1
             - name: IDLE_COLLECT_INTERVAL
-              value: 20
+              value: 100
             - name: CPU_FREQUENCY_ENABLED
               value: false
             pipelineRef:

--- a/model_training/tekton/examples/complete-pipelinerun.yaml
+++ b/model_training/tekton/examples/complete-pipelinerun.yaml
@@ -24,7 +24,7 @@ spec:
   - name: STRESS_BREAK_INTERVAL
     value: 1
   - name: IDLE_COLLECT_INTERVAL
-    value: 20
+    value: 100
   - name: CPU_FREQUENCY_ENABLED
     value: false
   pipelineRef:

--- a/model_training/tekton/examples/single-train/abs-power.yaml
+++ b/model_training/tekton/examples/single-train/abs-power.yaml
@@ -26,7 +26,7 @@ spec:
   - name: STRESS_BREAK_INTERVAL
     value: 1
   - name: IDLE_COLLECT_INTERVAL
-    value: 20
+    value: 100
   - name: CPU_FREQUENCY_ENABLED
     value: false
   pipelineRef:

--- a/model_training/tekton/examples/single-train/aws-push.yaml
+++ b/model_training/tekton/examples/single-train/aws-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: STRESS_BREAK_INTERVAL
     value: 1
   - name: IDLE_COLLECT_INTERVAL
-    value: 20
+    value: 100
   - name: CPU_FREQUENCY_ENABLED
     value: false
   pipelineRef:

--- a/model_training/tekton/examples/single-train/dyn-power.yaml
+++ b/model_training/tekton/examples/single-train/dyn-power.yaml
@@ -26,7 +26,7 @@ spec:
   - name: STRESS_BREAK_INTERVAL
     value: 1
   - name: IDLE_COLLECT_INTERVAL
-    value: 20
+    value: 100
   - name: CPU_FREQUENCY_ENABLED
     value: false
   pipelineRef:

--- a/model_training/tekton/examples/single-train/ibmcloud-push.yaml
+++ b/model_training/tekton/examples/single-train/ibmcloud-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: STRESS_BREAK_INTERVAL
     value: 1
   - name: IDLE_COLLECT_INTERVAL
-    value: 20
+    value: 100
   - name: CPU_FREQUENCY_ENABLED
     value: false
   pipelineRef:

--- a/model_training/tekton/examples/test-collect.yaml
+++ b/model_training/tekton/examples/test-collect.yaml
@@ -23,7 +23,7 @@ spec:
   - name: STRESS_BREAK_INTERVAL
     value: 1
   - name: IDLE_COLLECT_INTERVAL
-    value: 20
+    value: 100
   - name: CPU_FREQUENCY_ENABLED
     value: false
   pipelineRef:

--- a/src/train/pipeline.py
+++ b/src/train/pipeline.py
@@ -143,7 +143,7 @@ class Pipeline():
         if abs_data is None and dyn_data is None:
             return False, None, None
         if replace_node_type is not None:
-            self.print_log("Replace Node Type: ", replace_node_type)
+            self.print_log("Replace Node Type:  {}".format(replace_node_type))
             abs_data[node_info_column] = replace_node_type
             dyn_data[node_info_column] = replace_node_type
         self._train(abs_data, dyn_data, power_labels, energy_source, feature_group)
@@ -156,7 +156,7 @@ class Pipeline():
         if (abs_data is None or len(abs_data) == 0) and (dyn_data is None or len(dyn_data) == 0):
             return False, None, None
         if replace_node_type is not None:
-            self.print_log("Replace Node Type: ", replace_node_type)
+            self.print_log("Replace Node Type: {}".format(replace_node_type))
             abs_data[node_info_column] = replace_node_type
             dyn_data[node_info_column] = replace_node_type
         self._train(abs_data, dyn_data, power_labels, energy_source, feature_group)


### PR DESCRIPTION
Previously merged PR got error on retrain data from AWS COS. 
First error comes from too early collected data on COS. After recollecting and uploading to the COS, the first error is fixed and then I found another error comes in the code (pipeline.py). 

## first error
<img width="978" alt="Screenshot 2024-02-02 at 21 48 36" src="https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/53bb6997-d1b0-4624-9207-bfb670af7298">


## second error
<img width="902" alt="Screenshot 2024-02-02 at 21 48 15" src="https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/eed15da1-55af-4c16-ab7e-e6518838b0c4">

This PR fixes the error and update CI flow as follows:
- remove unnecessary docker login in integration test and tekton test
- add always condition to integration test and tekton test and check whether docker_secret is available instead. integration test and tekton test will run only when (1) no base change or (2) base change and has secret to build-push base. 
- add idle time to 100s to make sure that it has enough to create idle profile.

## fixed retrain result
<img width="1279" alt="Screenshot 2024-02-02 at 22 58 54" src="https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/f946fa57-4c45-4e7b-a2f4-7984a930a571">


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
