### PR TITLE
Add metadata plot and Fix bugs

### DIFF
--- a/cmd/cmd_plot.py
+++ b/cmd/cmd_plot.py
@@ -111,3 +111,39 @@ def summary_plot(args, energy_source, summary_df, output_folder, name):
     filename = os.path.join(output_folder, name + ".png")
     fig.savefig(filename)
     plt.close()
+
+def metadata_plot(args, energy_source, metadata_df, output_folder, name):
+    if metadata_df is None or len(metadata_df) == 0:
+        print("no metadata data to plot")
+        return
+
+    plot_height = 5
+    plot_width = 20
+
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    sns.set(font_scale=1.2)
+
+    energy_components = PowerSourceMap[energy_source]
+    col_num = len(energy_components)
+    fig, axes = plt.subplots(col_num, 1, figsize=(plot_width, plot_height*col_num))
+    for i in range(0, col_num):
+        component = energy_components[i]
+        metadata_df = metadata_df.sort_values(by="feature_group")
+        if col_num == 1:
+            ax = axes
+        else:
+            ax = axes[i]
+        sns.boxplot(data=metadata_df, x="feature_group", y="mae", hue="trainer", ax=ax, hue_order=sorted(metadata_df['trainer'].unique()), showfliers=False, palette="Set3")
+        ax.set_title(component)
+        ax.set_ylabel("MAE (Watt)")
+        ax.set_xlabel("Feature Group")
+        # ax.set_ylim((0, 100))
+        if i < col_num-1:
+            ax.set_xlabel("")
+       #  ax.legend(bbox_to_anchor=(1.05, 1.05))
+    plt.suptitle("Pipieline metadata of {} {}".format(energy_source.upper(), args.output_type))
+    plt.tight_layout()
+    filename = os.path.join(output_folder, name + ".png")
+    fig.savefig(filename)
+    plt.close()

--- a/cmd/cmd_util.py
+++ b/cmd/cmd_util.py
@@ -240,6 +240,7 @@ def check_ot_fg(args, valid_fg):
             exit()
     return ot, fg
 
+import sklearn
 def assert_train(trainer, data, energy_components):
     import pandas as pd
     node_types = pd.unique(data[node_info_column])
@@ -247,9 +248,12 @@ def assert_train(trainer, data, energy_components):
         node_type_filtered_data = data[data[node_info_column] == node_type]
         X_values = node_type_filtered_data[trainer.features].values
         for component in energy_components:
-            output = trainer.predict(node_type, component, X_values)
-            if output is not None:
-                assert len(output) == len(X_values), "length of predicted values != features ({}!={})".format(len(output), len(X_values))
+            try:
+                output = trainer.predict(node_type, component, X_values)
+                if output is not None:
+                    assert len(output) == len(X_values), "length of predicted values != features ({}!={})".format(len(output), len(X_values))
+            except sklearn.exceptions.NotFittedError:
+                pass
 
 def get_isolator(data_path, isolator, profile, pipeline_name, target_hints, bg_hints, abs_pipeline_name, replace_node_type=default_node_type):
     pipeline_path = get_pipeline_path(data_path, pipeline_name=pipeline_name)

--- a/model_training/s3/s3-loader.py
+++ b/model_training/s3/s3-loader.py
@@ -20,6 +20,7 @@ def ibmcloud_list_keys(client, bucket_name, prefix):
 
 def get_bucket_file_map(client, bucket_name, machine_id, mnt_path, pipeline_name, list_func):
     bucket_file_map = dict()
+    top_key_path = ""
     if machine_id is not None and machine_id != "":
         top_key_path = "/" + machine_id
     # add data key map

--- a/src/train/exporter/validator.py
+++ b/src/train/exporter/validator.py
@@ -88,13 +88,16 @@ class BestModelCollection():
 # get_validated_export_items return valid export items
 def get_validated_export_items(pipeline_path, pipeline_name):
     export_items = []
+    valid_metadata_df = dict()
     models_path = os.path.join(pipeline_path, "..")
     for energy_source in PowerSourceMap.keys():
+        valid_metadata_df[energy_source] = dict()
         for ot in ModelOutputType:
             metadata_df = load_pipeline_metadata(pipeline_path, energy_source, ot.name)
             if metadata_df is None:
                 print("no metadata for", energy_source, ot.name)
                 continue
+            valid_rows = []
             for _, row in metadata_df.iterrows():
                 if row['mape'] <= mape_threshold or row['mae'] <= mae_threshold:
                     model_name = row["model_name"]
@@ -105,4 +108,6 @@ def get_validated_export_items(pipeline_path, pipeline_name):
                         print("source not exist: ", source_file)
                         continue
                     export_items += [export_item]
-    return export_items
+                    valid_rows += [row]
+            valid_metadata_df[energy_source][ot.name] = pd.DataFrame(valid_rows)
+    return export_items, valid_metadata_df

--- a/src/train/exporter/writer.py
+++ b/src/train/exporter/writer.py
@@ -7,8 +7,9 @@ util_path = os.path.join(os.path.dirname(__file__), '..', '..', 'util')
 sys.path.append(util_path)
 
 from loader import load_json, version
-from saver import assure_path
+from saver import assure_path,  _pipeline_model_metadata_filename
 from validator import mae_threshold, mape_threshold
+from train_types import ModelOutputType, PowerSourceMap
 
 error_report_foldername = "error_report"
 
@@ -201,7 +202,6 @@ def generate_pipeline_readme(pipeline_name, local_export_path, node_type_index_j
     markdown_filepath = os.path.join(local_export_path, "README.md")
     markdown_content = "# {} on v{} Build\n\n".format(pipeline_name, version)
     markdown_content += "MAE Threshold = {}, MAPE Threshold = {}%\n\n".format(mae_threshold, int(mape_threshold))
-    
     items = []
     for node_type, spec_json in node_type_index_json.items():
         if best_model_collections[int(node_type)].has_model:
@@ -213,6 +213,12 @@ def generate_pipeline_readme(pipeline_name, local_export_path, node_type_index_j
             items += [item]
     df = pd.DataFrame(items)
     markdown_content += "Available Node Type: {}\n\n".format(len(df))
+    # add metadata figures
+    for ot in ModelOutputType:
+        for energy_source in PowerSourceMap.keys():
+            data_filename = _pipeline_model_metadata_filename(energy_source, ot.name)
+            markdown_content += "![]({}.png)\n".format(data_filename)
+
     markdown_content += data_to_markdown_table(df.sort_values(by=["node type"]))
     write_markdown(markdown_filepath, markdown_content)
     return markdown_filepath

--- a/src/train/pipeline.py
+++ b/src/train/pipeline.py
@@ -117,7 +117,7 @@ class Pipeline():
 
     def _train(self, abs_data, dyn_data, power_labels, energy_source, feature_group):
         # start the thread pool
-        with ThreadPoolExecutor(2) as executor:
+        with ThreadPoolExecutor(len(self.trainers)) as executor:
             futures = []
             for trainer in self.trainers:
                 if trainer.feature_group_name != feature_group:

--- a/src/train/profiler/node_type_index.py
+++ b/src/train/profiler/node_type_index.py
@@ -44,7 +44,7 @@ def generate_spec(data_path, machine_id):
     if "brand_raw" in cpu_info:
         processor = format_processor(cpu_info["brand_raw"])
     cores = psutil.cpu_count(logical=True)
-    chips = psutil.cpu_count(logical=False)
+    chips = int(cores/psutil.cpu_count(logical=False))
     memory = psutil.virtual_memory().total
     memory_gb = int(memory/GB)
     cpu_freq_mhz = round(psutil.cpu_freq(percpu=False).max/100)*100 # round to one decimal of GHz


### PR DESCRIPTION
This PR includes two updates.

- Add metadata plot on export as below:

![Screenshot 2024-02-09 at 20 36 57](https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/78628641-e75e-4978-950c-9cf34a705974)

- Fix bugs:
    - training pipeline stops when one of node_type is failed to be trained (some curvefit cannot find a fit curve on some specific data). --> fixed by adding try-catch on metadata save
    - number of chips is miscalculated. --> changed to chips = int(cores/psutil.cpu_count(logical=False))
    - increase trainer threads to be equal to the number of trainer
    - top_key_path on s3 not initialized. 
    
  Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
    