### PR TITLE
update curvefit (log func) and generate_spec 

### DIFF
--- a/.github/workflows/push-pr.yml
+++ b/.github/workflows/push-pr.yml
@@ -153,7 +153,7 @@ jobs:
           echo "change=true" >> "$GITHUB_OUTPUT"
 
   tekton-test:
-    needs: [check-secret, check-branch, base-image]
+    needs: [check-secret, check-branch, check-change, base-image]
     if: always()
     uses: ./.github/workflows/tekton-test.yml
     with:
@@ -164,7 +164,7 @@ jobs:
       pipeline_name: std_v0.7
 
   integration-test:
-    needs: [check-secret, check-branch, base-image]
+    needs: [check-secret, check-branch, check-change, base-image]
     if: always()
     uses: ./.github/workflows/integration-test.yml
     with:

--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -13,3 +13,4 @@ scikit-learn==1.1.2
 py-cpuinfo==9.0.0
 seaborn==0.12.2
 psutil==5.9.8
+pyudev==0.24.1

--- a/src/train/trainer/ExponentialRegressionTrainer/main.py
+++ b/src/train/trainer/ExponentialRegressionTrainer/main.py
@@ -6,6 +6,13 @@ sys.path.append(trainer_path)
 from trainer.curvefit import CurveFitTrainer, CurveFitModel
 
 import numpy as np
+import math
+
+def p0_func(x, y):
+    a = (y.max()-y.min())//math.e # scale value
+    b = 1 # start from linear
+    c = y.min() - a # initial offset
+    return [a,b,c]
 
 def expo_func(x, a, b, c):
     y = a*np.exp(b*x) + c 
@@ -18,4 +25,4 @@ class ExponentialRegressionTrainer(CurveFitTrainer):
         self.fe_files = []
     
     def init_model(self):
-        return CurveFitModel(expo_func)
+        return CurveFitModel(expo_func, p0_func=p0_func)

--- a/src/train/trainer/LogarithmicRegressionTrainer/main.py
+++ b/src/train/trainer/LogarithmicRegressionTrainer/main.py
@@ -8,13 +8,13 @@ from trainer.curvefit import CurveFitTrainer, CurveFitModel
 import numpy as np
 
 def p0_func(x, y):
-    print(y.max(), y.min())
     a = y.max()-y.min()
-    b = y.min()
-    return [a, b]
+    b = 1
+    c = y.min()
+    return [a, b, c]
 
-def log_func(x, a, b):
-    y = [a * np.log(xi) + b if xi > 0 else 0 for xi in x]
+def log_func(x, a, b, c):
+    y = a*np.log(b*x+1) + c
     return y
 
 class LogarithmicRegressionTrainer(CurveFitTrainer):

--- a/src/train/trainer/LogisticRegressionTrainer/main.py
+++ b/src/train/trainer/LogisticRegressionTrainer/main.py
@@ -10,7 +10,7 @@ import numpy as np
 def p0_func(x, y):
     A = y.max() - y.min() # value range
     x0 = 0.5 # sigmoid mid point (as normalized value is in 0 to 1, start mid point = 0.5)
-    k = A/np.std(y) # growth rate (larger std, lower growth)
+    k = A//np.std(y) # growth rate (larger std, lower growth)
     off = y.min() # initial offset
     return [A,x0,k,off]
 

--- a/src/train/trainer/curvefit.py
+++ b/src/train/trainer/curvefit.py
@@ -36,9 +36,9 @@ class CurveFitModel():
         flatten_x = self._x_values(X_values)
         flatten_y = np.array(y_values).flatten()
         if self.p0_func is not None:
-            self.popt, self.pcov = curve_fit(self.fit_func, flatten_x, flatten_y, p0=self.p0_func(flatten_x, flatten_y), maxfev=20000)
+            self.popt, self.pcov = curve_fit(self.fit_func, flatten_x, flatten_y, p0=self.p0_func(flatten_x, flatten_y), maxfev=30000)
         else:
-            self.popt, self.pcov = curve_fit(self.fit_func, flatten_x, flatten_y, maxfev=20000)
+            self.popt, self.pcov = curve_fit(self.fit_func, flatten_x, flatten_y, maxfev=30000)
     
     def predict(self, X_values):
         if self.popt is None:


### PR DESCRIPTION
This PR includes the following improvement.
curvefit function:
- improve log fitting function by adding coefficient and bias value to avoid log(0) instead of if condition
- update log p0 function
- add p0 function for exponential for faster convergence
- increase maxfev for better fitting (especially for logistic function which is the most complex)
generate_spec:
- add vendor extraction (available only on BM so not include in the main specification yet)
- reformat processor with lower function
- correct chips number calculation and add threads_per_core
- for VM, max frequency is zero, use current instead

The updated results can be found [here](https://github.com/sunya-ch/kepler-model-db/tree/specpower/models/v0.7/specpower).

Before:
![image](https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/b1a55d67-e35a-47dd-9d06-24c89ffa25ae)

After:
![image](https://github.com/sustainable-computing-io/kepler-model-server/assets/11749848/d572a0c0-d244-470d-9f85-50ae38afaa2c)

Significant improvement can be observed for LogarithmicRegressionTrainer.

Minor fix:
- add missing check-change need on CI

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>