### PR TITLE
specify kepler tag

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,10 +18,16 @@ on:
         description: 'The image tag to use'
         required: true
         type: string
+      kepler_tag:
+        description: 'Kepler image tag'
+        required: true
+        type: string
 
 env:
   BASE_IMAGE: ${{ inputs.image_repo }}/kepler_model_server_base:${{ inputs.image_tag }}
   IMAGE: localhost:5001/kepler_model_server:devel
+  KEPLER_IMAGE: quay.io/sustainable_computing_io/kepler:${{ inputs.kepler_tag }}
+  DEFAULT_MODEL_SERVER_BASE_IMAGE: quay.io/sustainable_computing_io/kepler_model_server_base:v0.7
 
 jobs:
   run-integration:
@@ -34,10 +40,10 @@ jobs:
           runningBranch: kind
           cluster_provider: kind
           local_dev_cluster_version: v0.0.3
-      - name: load latest kepler image
+      - name: load kepler image
         run: |
-          docker pull quay.io/sustainable_computing_io/kepler:latest
-          kind load docker-image quay.io/sustainable_computing_io/kepler:latest
+          docker pull ${{ env.KEPLER_IMAGE }}
+          kind load docker-image ${{ env.KEPLER_IMAGE }}
       - name: checkout
         uses: actions/checkout@v4
       - name: set up QEMU
@@ -47,11 +53,11 @@ jobs:
       - name: Replace value in Dockerfile if base changes
         if: ${{ (inputs.base_change == 'true') && (inputs.docker_secret == 'true') }}
         run: |
-          sed -i "s|quay.io/sustainable_computing_io/kepler_model_server_base:v0.7|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile
+          sed -i "s|${{ env.DEFAULT_MODEL_SERVER_BASE_IMAGE }}|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile
       - name: Replace value in Dockerfile.test if base changes
         if: ${{ (inputs.base_change == 'true') && (inputs.docker_secret == 'true') }}
         run: |
-          sed -i "s|quay.io/sustainable_computing_io/kepler_model_server_base:v0.7|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile.test
+          sed -i "s|${{ env.DEFAULT_MODEL_SERVER_BASE_IMAGE }}|${{ env.BASE_IMAGE }}|" dockerfiles/Dockerfile.test
       - name: build Kepler model server and test image and push to local registry
         run: make build build-test push push-test
       - name: set up Kustomize

--- a/.github/workflows/push-pr.yml
+++ b/.github/workflows/push-pr.yml
@@ -18,6 +18,9 @@ on:
     - '*.md'
     - '**/*.md'
 
+env:
+  TAG: "v0.7.7"
+
 jobs:
   check-branch:
     runs-on: ubuntu-latest
@@ -37,7 +40,7 @@ jobs:
             echo "tag=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
           else
             if [ "$BRANCH" == "main" ]; then
-                echo "tag=v0.7" >> "$GITHUB_OUTPUT"
+                echo "tag=${{ env.TAG }}" >> "$GITHUB_OUTPUT"
             else
                 echo "tag=$COMMIT" >> "$GITHUB_OUTPUT"
             fi
@@ -172,3 +175,4 @@ jobs:
       docker_secret: ${{ needs.check-secret.outputs.docker-secret }}
       image_repo: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
       image_tag: ${{ needs.check-branch.outputs.tag }}
+      kepler_tag: release-0.7.7

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
 
+env:
+  TAG: "v0.7.7"
+
 jobs:
   check-change:
     runs-on: ubuntu-latest
@@ -33,7 +36,7 @@ jobs:
     with:
       base_change: ${{ needs.check-change.outputs.base }}
       image_repo: ${{ vars.IMAGE_REPO }}
-      image_tag: v0.7
+      image_tag: ${{ env.TAG }}
       push: true
     secrets:
       docker_username: ${{ secrets.BOT_NAME }}
@@ -51,7 +54,7 @@ jobs:
       instance_type: ${{ matrix.instance_type }}
       ami_id: 'ami-0e4d0bb9670ea8db0'
       github_repo: ${{ github.repository }}
-      model_server_image: ${{ vars.IMAGE_REPO }}/kepler_model_server:v0.7
+      model_server_image: ${{ vars.IMAGE_REPO }}/kepler_model_server:${{ env.TAG }}
       trainers: LogisticRegressionTrainer,ExponentialRegressionTrainer,SGDRegressorTrainer,GradientBoostingRegressorTrainer,XgboostFitTrainer
     secrets:
       self_hosted_github_token: ${{ secrets.GH_SELF_HOSTED_RUNNER_TOKEN }}

--- a/manifests/kepler/patch/patch-ci.yaml
+++ b/manifests/kepler/patch/patch-ci.yaml
@@ -17,4 +17,4 @@ spec:
       containers:
       - name: kepler-exporter
         imagePullPolicy: IfNotPresent
-        image: quay.io/sustainable_computing_io/kepler:latest
+        image: quay.io/sustainable_computing_io/kepler:release-0.7.7

--- a/model_training/deployment/kepler.yaml
+++ b/model_training/deployment/kepler.yaml
@@ -204,7 +204,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: quay.io/sustainable_computing_io/kepler:latest
+        image: quay.io/sustainable_computing_io/kepler:release-0.7.7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
According to the action error https://github.com/sustainable-computing-io/kepler-model-server/actions/runs/8050258211/job/22588827198, it seems model server is failed to collect the energy data with latest kepler image.

```
==== bpf ====
1 pods: 	Valid

Valid data points:
            >0
scenarioID    
            20
intel_rapl data: 	[0]
acpi data: 	[0]
pod/test-collect-presteps-pod
Empty
==== bpf ====
1 pods: 	No data for ['']
1 pods: 	Zero data for ['']
0 pods: 	Valid

Valid data points:
Empty
intel_rapl data: 	[0]
acpi data: 	[0]
```

To freeze the supported version, this PR specifies a specific Kepler release version that should support (v0.7.7). 


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>