### PR TITLE
fix logic to obtain new model

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -66,7 +66,9 @@ jobs:
         run: make build build-test push push-test
       - name: set up Kustomize
         run: |
-          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          curl -o install_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh
+          chmod +x install_kustomize.sh
+          ./install_kustomize.sh 5.3.0
           chmod +x kustomize
           mv kustomize /usr/local/bin/
       - name: test deploying with only estimator

--- a/manifests/base/patch/patch-estimator-sidecar.yaml
+++ b/manifests/base/patch/patch-estimator-sidecar.yaml
@@ -1,4 +1,3 @@
-# TODO: change to official path when kepler-model-db#22 merged
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/manifests/base/patch/patch-server-only.yaml
+++ b/manifests/base/patch/patch-server-only.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kepler-cfm
+  namespace: kepler
+data:
+  MODEL_CONFIG: |
+    NODE_COMPONENTS_TRAINER=SGDRegressorTrainer
+    NODE_TOTAL_TRAINER=SGDRegressorTrainer

--- a/manifests/base/serve-only/kustomization.yaml
+++ b/manifests/base/serve-only/kustomization.yaml
@@ -9,6 +9,7 @@ images:
 
 patchesStrategicMerge:
 - ./patch/patch-model-server.yaml
+- ./patch/patch-server-only.yaml
 resources:
 - ../kepler
 - ../server

--- a/src/estimate/estimator.py
+++ b/src/estimate/estimator.py
@@ -61,14 +61,14 @@ def handle_request(data):
     if output_type.name not in loaded_model:
         loaded_model[output_type.name] = dict()
     output_path = ""
-    request_trainer = True
+    request_trainer = False
     if power_request.trainer_name is not None:
         if output_type.name in loaded_model and power_request.energy_source in loaded_model[output_type.name]:
             current_trainer = loaded_model[output_type.name][power_request.energy_source].trainer_name
-            request_trainer = current_trainer == power_request.trainer_name
-            if not request_trainer:
+            request_trainer = current_trainer != power_request.trainer_name
+            if request_trainer:
                 print("try obtaining the requesting trainer {} (current: {})".format(power_request.trainer_name, current_trainer))
-    if power_request.energy_source not in loaded_model[output_type.name] or not request_trainer:
+    if power_request.energy_source not in loaded_model[output_type.name] or request_trainer:
         output_path = get_download_output_path(download_path, power_request.energy_source, output_type)
         if not os.path.exists(output_path):
             # try connecting to model server


### PR DESCRIPTION
The current logic to obtain a new power model when getting a request and the requesting trainer is different from the current cache of power model is wrong.
It should set to False by default and set to True only when the current trainer is not equal to the requesting trainer name.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>