### PR TITLE
change kepler config path and export func name

### DIFF
--- a/manifests/kepler/kustomization.yaml
+++ b/manifests/kepler/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - github.com/sustainable-computing-io/kepler/manifests/config/base
+  - github.com/sustainable-computing-io/kepler/manifests/k8s/config/base
 
 patchesStrategicMerge:
 - ./patch/patch-ci.yaml

--- a/model_training/cpe_script_instruction.md
+++ b/model_training/cpe_script_instruction.md
@@ -104,17 +104,17 @@ Compatible version: python 3.8
 
 1. Fork `kepler-model-db`.
 
-1. Validate and make a copy by export command. Need to define `machine id`, `local path to forked kepler-model-db/models`, `author github account` and `benchmark type`.
+1. Validate and make a copy by export_models command. Need to define `machine id`, `local path to forked kepler-model-db/models`, `author github account` and `benchmark type`.
 
     Run
     ```
-    ./script.sh export <machine id> <path to kepler-model-db/models> <author github account> <benchmark type>
+    ./script.sh export_models <machine id> <path to kepler-model-db/models> <author github account> <benchmark type>
     ```
 
     If you also agree to share the raw data (preprocessed data and archived file of full pipeline), run
 
     ```
-    ./script.sh export_with_raw <machine id> <path to kepler-model-db/models> <author github account> <benchmark type>
+    ./script.sh export_models_with_raw <machine id> <path to kepler-model-db/models> <author github account> <benchmark type>
     ```
 
     - set `NATIVE="true"` to export natively.

--- a/model_training/script.sh
+++ b/model_training/script.sh
@@ -230,11 +230,11 @@ function _export() {
     fi
 }
 
-function export() {
+function export_models() {
     _export $1 $2 $3 $4
 }
 
-function export_with_raw() {
+function export_models_with_raw() {
     _export $1 $2 $3 $4 "--include-raw true"
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/sustainable-computing-io/kepler-model-server/pull/252#issuecomment-2065632597, the config path on Kepler repository has been changed. This PR updates the path. 

In addition, this PR also change export function name to prevent issue as reported in https://github.com/sustainable-computing-io/kepler-model-server/issues/251.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>