### PR TITLE
update local_dev_cluster_version to v0.0.5

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -39,11 +39,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: use Kepler action to deploy cluster
-        uses: sustainable-computing-io/kepler-action@v0.0.6
+        uses: sustainable-computing-io/kepler-action@v0.0.7
         with:
           runningBranch: kind
           cluster_provider: kind
-          local_dev_cluster_version: v0.0.3
+          local_dev_cluster_version: v0.0.5
       - name: load kepler image
         run: |
           docker pull ${{ env.KEPLER_IMAGE }}


### PR DESCRIPTION
Fix issue https://github.com/sustainable-computing-io/kepler-action/issues/118 by upgrading local_dev_cluster_version.

credit: @SamYuan1990 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>