### PR TITLE
[CI nit] use a fixed kepler-action version as found some PR may change kubecon…

### DIFF
--- a/.github/workflows/collect-data-self-hosted.yml
+++ b/.github/workflows/collect-data-self-hosted.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: use Kepler action to deploy cluster
-        uses: sustainable-computing-io/kepler-action@main
+        uses: sustainable-computing-io/kepler-action@v0.0.7
         with:
           ebpfprovider: libbpf
           cluster_provider: kind

--- a/.github/workflows/tekton-test.yml
+++ b/.github/workflows/tekton-test.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           docker build -t $IMAGE -f dockerfiles/Dockerfile .
       - name: use Kepler action to deploy cluster
-        uses: sustainable-computing-io/kepler-action@main
+        uses: sustainable-computing-io/kepler-action@v0.0.7
         with:
           ebpfprovider: libbpf
           cluster_provider: kind

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -116,7 +116,7 @@ jobs:
               sudo pip3 install awscli
 
       - name: use Kepler action to deploy cluster
-        uses: sustainable-computing-io/kepler-action@main
+        uses: sustainable-computing-io/kepler-action@v0.0.7
         with:
           ebpfprovider: libbpf
           cluster_provider: kind


### PR DESCRIPTION
 use a fixed kepler-action version as found some PR may change kubeconfig path

kepler-action has it daily check to avoid it failure, same daily check is adding to local-dev-cluster.