### PR TITLE
try to build binary file

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check-out repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          cache: 'pip'
+          cache-dependency-path: |
+            dockerfiles/requirements*.txt
+
+      - name: Install Dependencies
+        run: |
+          pip install -r dockerfiles/requirements.txt
+          pip install pyinstaller
+
+      - name: build
+        run: |
+          pyinstaller ./cmd/main.py 
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            build/main/main


### PR DESCRIPTION
@sunya-ch  could you please test this PR manually on your laptop?
I tried pyinstaller and get a binary in 11M https://github.com/SamYuan1990/kepler-model-server/actions/runs/9402717115
if so, which means, we can just use binary to start model server instead of having so many python modules in container image?