### PR TITLE
WIP Include Production WSGI (Gunicorn) to replace Flask Default Server

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -18,4 +18,6 @@ EXPOSE 8101
 # port for Offline Trainer
 EXPOSE 8102
 
+CMD ["gunicorn", "--bind", "0.0.0.0:8100", "src.server.model_server:app"]
+
 ENTRYPOINT ["python3.8", "cmd/main.py"]

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -24,4 +24,5 @@ EXPOSE 8101
 # port for Offline Trainer
 EXPOSE 8102
 
-CMD [ "python3.8", "-u", "src/server/model_server.py" ]
+#CMD [ "python3.8", "-u", "src/server/model_server.py" ]
+CMD ["gunicorn", "--bind", "0.0.0.0:8100", "src.server.model_server:app"]

--- a/dockerfiles/Dockerfile.test-nobase
+++ b/dockerfiles/Dockerfile.test-nobase
@@ -25,4 +25,5 @@ EXPOSE 8101
 # port for Offline Trainer
 EXPOSE 8102
 
-CMD [ "python3.8", "-u", "src/server/model_server.py" ]
+# CMD [ "python3.8", "-u", "src/server/model_server.py" ]
+CMD ["gunicorn", "-b", "0.0.0.0:8100", "src.server.model_server:app"]

--- a/dockerfiles/requirements.txt
+++ b/dockerfiles/requirements.txt
@@ -1,4 +1,5 @@
 flask==2.1.2
+gunicorn==22.0.0
 Werkzeug==2.2.2
 protobuf==3.19.4
 pandas==1.4.4


### PR DESCRIPTION
To Address: https://github.com/sustainable-computing-io/kepler-model-server/issues/259

A side effect of using Gunicorn is that it will replace the address with default address and default port (8000). This can be resolved by binding (ex. binding model_server to 0.0.0.0:8100). Binding with 0.0.0.0 is acceptable but according to [Flask](https://flask.palletsprojects.com/en/3.0.x/deploying/gunicorn/), it is better to also introduce nginx server to act as a reverse proxy. Will this be necessary to include? 

Also, since model_server AND offline_trainer (and in future online_trainer) expects to use their own Flask Apps, supervisord is needed to run multiple CMD for model_server and offline_trainer in Dockerfile. 

Currently, this changes here works for metal docker compose so long as  python3.8 -u src/server/model_server.py is replaced by gunicorn -b -0.0.0.0.8100 -src.server.model_server:app. However, there is more functionality that can be introduced depending on what is acceptable or not. 