### PR TITLE
chore(pyproject): fix pip install not installing all packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ path = "src/__about__.py"
 packages = [
 	"src/server", 
 	"src/estimate",
+	"src/util",
+	"src/train",
 ]
 
 [tool.hatch.envs.default]


### PR DESCRIPTION
This fixes `pip install .` which installs `model-server` and `estimator` that 
also requires `util` and `train` to be installed as well.
