### PR TITLE
fix(model-training): revert to python3.8 for s3 scripts

### DIFF
--- a/model_training/tekton/tasks/s3/aws-s3-load.yaml
+++ b/model_training/tekton/tasks/s3/aws-s3-load.yaml
@@ -45,7 +45,7 @@ spec:
           secretKeyRef:
             name: $(params.COS_SECRET_NAME)
             key: bucketName
-      command: ["python3.10"]
+      command: ["python3.8"]
       args:
       - s3-loader.py
       - aws

--- a/model_training/tekton/tasks/s3/aws-s3-push.yaml
+++ b/model_training/tekton/tasks/s3/aws-s3-push.yaml
@@ -42,7 +42,7 @@ spec:
           secretKeyRef:
             name: $(params.COS_SECRET_NAME)
             key: bucketName
-      command: ["python3.10"]
+      command: ["python3.8"]
       args:
       - s3-pusher.py
       - aws

--- a/model_training/tekton/tasks/s3/ibmcloud-s3-load.yaml
+++ b/model_training/tekton/tasks/s3/ibmcloud-s3-load.yaml
@@ -45,7 +45,7 @@ spec:
           secretKeyRef:
             name: $(params.COS_SECRET_NAME)
             key: bucketName
-      command: ["python3.10"]
+      command: ["python3.8"]
       args:
       - s3-loader.py
       - ibmcloud

--- a/model_training/tekton/tasks/s3/ibmcloud-s3-push.yaml
+++ b/model_training/tekton/tasks/s3/ibmcloud-s3-push.yaml
@@ -42,7 +42,7 @@ spec:
           secretKeyRef:
             name: $(params.COS_SECRET_NAME)
             key: bucketName
-      command: ["python3.10"]
+      command: ["python3.8"]
       args:
       - s3-pusher.py
       - ibmcloud


### PR DESCRIPTION
The[ image used for s3](https://quay.io/repository/sustainability/kepler_model_server/s3/manifest/sha256:c92c40a0e2974146d8d87931bc5d36e062105e23b3660ec0cb40183dc979c63f) step still uses python 3.8 and needs to be rebuilt before switching to python 3.10
