### PR TITLE
ci: build base image if a change is detected

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -92,7 +92,6 @@ jobs:
       if: ${{ (needs.check-secret.outputs.available == 'true') && ((needs.check-base-exist.outputs.exists == 'false') || (env.base_change == 'true')) }} 
       uses: docker/build-push-action@v6
       with:
-        context: dockerfiles
         platforms: linux/amd64
         push: true
         tags: ${{ env.base_image }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -119,8 +119,8 @@ jobs:
       base_change: ${{ needs.check-change.outputs.base }}
 
   base-image:
-    if: ${{ (needs.check-secret.outputs.docker-secret == 'true') && ((needs.check-base-exist.outputs.exists == 'false') || (needs.check-change.outputs.base == 'true')) }}
-    needs: [check-base-exist, check-branch, check-secret, check-change]
+    if: ${{ (needs.check-base-exist.outputs.exists == 'false') || (needs.check-change.outputs.base == 'true') }}
+    needs: [check-base-exist, check-branch, check-change]
     runs-on: ubuntu-latest
 
     outputs:
@@ -136,17 +136,10 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker
-        uses: docker/login-action@v3
-        with:
-            registry: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
-            username: ${{ secrets.BOT_NAME }}
-            password: ${{ secrets.BOT_TOKEN }} 
-      - name: Build-push base image
+      - name: Build base image
         uses: docker/build-push-action@v6
         with:
-          context: dockerfiles
-          push: true
+          push: false
           tags: ${{ vars.IMAGE_REPO || 'docker.io/library' }}/kepler_model_server_base:${{ needs.check-branch.outputs.tag }}
           file: dockerfiles/Dockerfile.base
       - name: Record change

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IMAGE_NAME := kepler_model_server
 IMAGE_VERSION := 0.7
 
 IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):v$(IMAGE_VERSION)
+BASE_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)_base:v$(IMAGE_VERSION)
 LATEST_TAG_IMAGE := $(IMAGE_REGISTRY)/$(IMAGE_NAME):latest
 TEST_IMAGE := $(IMAGE)-test
 
@@ -13,6 +14,9 @@ MODEL_PATH := ${PWD}/tests/models
 
 build:
 	$(CTR_CMD) build -t $(IMAGE) -f $(DOCKERFILES_PATH)/Dockerfile .
+
+build-base:
+	$(CTR_CMD) build -t $(BASE_IMAGE) -f $(DOCKERFILES_PATH)/Dockerfile.base .
 
 build-test-nobase:
 	$(CTR_CMD) build -t $(TEST_IMAGE) -f $(DOCKERFILES_PATH)/Dockerfile.test-nobase .

--- a/dockerfiles/Dockerfile.base
+++ b/dockerfiles/Dockerfile.base
@@ -2,9 +2,13 @@ FROM python:3.10-slim
 RUN pip install --no-cache-dir --upgrade pip
 
 COPY pyproject.toml .
+
 # NOTE: README.md and __about__.py are referenced in pyproject.toml
-# so that they are copied into the image for pip install to succeed
+# so they are copied into the image for pip install to succeed
 COPY README.md .
+
+RUN mkdir -p src
 COPY src/__about__.py src/
+
 RUN pip install --no-cache-dir . && \
 		pip cache purge


### PR DESCRIPTION
This PR builds (but not push) base image if a change is detected in critical files.

This should help detect issues such as https://github.com/sustainable-computing-io/kepler-model-server/actions/runs/9834078233 where the build-and-push base failed after the PR was merged.
