### PR TITLE
enrich ec2 train/plot and remove replacement of NodeAttribute.PROCESSOR with instance profile

### DIFF
--- a/cmd/main.py
+++ b/cmd/main.py
@@ -681,8 +681,11 @@ def plot(args):
                 feature_cols = FeatureGroups[fg]
                 scaler = MaxAbsScaler()
                 data[feature_cols] = best_restult[[TIMESTAMP_COL] + feature_cols].groupby([TIMESTAMP_COL]).sum().sort_index()
+                # plot raw feature data to confirm min-max value
+                ts_plot(data, feature_cols, "Features {}".format(fg) , output_folder, "{}_{}".format(data_filename, fg), labels=None, subtitles=None, ylabel=None)
                 data[feature_cols] = scaler.fit_transform(data[feature_cols])
                 feature_power_plot(data, model_id, ot.name, energy_source, feature_cols, actual_power_cols, predicted_power_cols, output_folder, "{}_{}_corr".format(data_filename, model_id))
+
     elif args.target_data == "error":
         from estimate import default_predicted_col_func
         from sklearn.preprocessing import MaxAbsScaler

--- a/src/train/exporter/exporter.py
+++ b/src/train/exporter/exporter.py
@@ -61,7 +61,7 @@ def export(data_path, pipeline_path, db_path, publisher, collect_date, inputs):
         best_model_collections[export_item.node_type].compare_new_item(export_item)
     
     # generate pipeline page
-    workload_content = workload_content = get_workload_content(data_path, inputs)
+    workload_content = get_workload_content(data_path, inputs)
     generate_pipeline_page(local_version_path, pipeline_metadata, workload_content)
     # generate error report page
     generate_report_results(local_export_path, best_model_collections, node_type_index_json, remote_version_path)

--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -71,7 +71,7 @@ wait_for_db() {
 }
 
 wait_for_keyword() {
-    num_iterations=10
+    num_iterations=30
     component=$1
     keyword=$2
     message=$3


### PR DESCRIPTION
To provide more visualization of collected data on EC2, I add lines to save kepler_query_json and machine spec to the local path for later feature plot. 

In addition, this PR also contains minor fix (duplicated workload_content assignment) and remove overwriting of NodeAttribute.PROCESSOR to keep information of processor model instead of replacing with instance profile name.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>