### PR TITLE
update instance list and pipeline for ec2-0.7.11

### DIFF
--- a/cmd/cmd_plot.py
+++ b/cmd/cmd_plot.py
@@ -155,7 +155,10 @@ def metadata_plot(args, energy_source, metadata_df, output_folder, name):
     plt.close()
 
 def power_curve_plot(args, data_path, energy_source, output_folder, name):
-    model_toppath = data_path
+    if 'MODEL_PATH' in os.environ:
+        model_toppath = os.environ['MODEL_PATH']
+    else:
+        model_toppath = data_path
     pipeline_name = args.pipeline_name
     pipeline_path = os.path.join(model_toppath, pipeline_name)
     node_collection = NodeTypeIndexCollection(pipeline_path)

--- a/cmd/cmd_util.py
+++ b/cmd/cmd_util.py
@@ -28,7 +28,7 @@ def print_file_to_stdout(data_path, args):
 
 def extract_time(data_path, benchmark_filename):
     data = load_json(data_path, benchmark_filename)
-    if benchmark_filename != "customBenchmark":
+    if "metadata" in data:
         start_str = data["metadata"]["creationTimestamp"]
         start = datetime.datetime.strptime(start_str, '%Y-%m-%dT%H:%M:%SZ')
         end_str = data["status"]["results"][-1]["repetitions"][-1]["pushedTime"].split(".")[0]

--- a/cmd/main.py
+++ b/cmd/main.py
@@ -394,6 +394,7 @@ def train(args):
     dyn_trainer_names = args.dyn_trainers.split(",")
     
     node_type=None
+    pipeline=None
     if args.id:
         machine_id = args.id
         pipeline = get_pipeline(data_path, pipeline_name, args.extractor, args.profile, args.target_hints, args.bg_hints, args.abs_pipeline_name, args.isolator, abs_trainer_names, dyn_trainer_names, energy_sources, valid_feature_groups)
@@ -749,9 +750,15 @@ def export(args):
         inputs = args.input.split(",")
 
     pipeline_name = args.pipeline_name
-    pipeline_path = get_pipeline_path(data_path, pipeline_name=pipeline_name)
+    if 'MODEL_PATH' not in os.environ:
+        os.environ['MODEL_PATH'] = data_path
+    pipeline_path = get_pipeline_path(os.environ['MODEL_PATH'], pipeline_name=pipeline_name)
 
     local_export_path = exporter.export(data_path, pipeline_path, output_path, publisher=args.publisher, collect_date=collect_date, inputs=inputs)
+
+    if local_export_path is None:
+        print("failed to export")
+        exit()
 
     args.input = local_export_path
     args.output = local_export_path

--- a/src/train/profiler/node_type_index.py
+++ b/src/train/profiler/node_type_index.py
@@ -2,7 +2,7 @@
 #p
 # Usage:
 #   index_collection = NodeTypeIndexCollection(pipeline_path)
-#   node_type = index_collection.index_train_machine(processor, cores, chips, cache_kb, memory_gb, cpu_freq_mhz, power_mgt, minmax_watt)
+#   node_type = index_collection.index_train_machine(machine_id, new_spec)
 #   index_collection.save()
 
 import sys
@@ -68,8 +68,8 @@ def generate_spec(data_path, machine_id):
         "processor": processor,
         "cores": cores,
         "chips": chips,
-        "memory_gb": memory_gb,
-        "cpu_freq_mhz": cpu_freq_mhz,
+        "memory": memory_gb,
+        "frequency": cpu_freq_mhz,
         "threads_per_core": threads_per_core
     }
     spec = NodeTypeSpec(**spec_values)
@@ -102,8 +102,8 @@ class NodeTypeSpec():
         self.attrs[NodeAttribute.PROCESSOR] = kwargs.get('processor', no_data)
         self.attrs[NodeAttribute.CORES] = kwargs.get('cores', no_data)
         self.attrs[NodeAttribute.CHIPS] = kwargs.get('chips', no_data)
-        self.attrs[NodeAttribute.MEMORY] = kwargs.get('memory_gb', no_data)
-        self.attrs[NodeAttribute.FREQ] = kwargs.get('cpu_freq_mhz', no_data)
+        self.attrs[NodeAttribute.MEMORY] = kwargs.get('memory', no_data)
+        self.attrs[NodeAttribute.FREQ] = kwargs.get('frequency', no_data)
         self.members = []
         
     def load(self, json_obj):

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -21,8 +21,8 @@ spec_values =   {
                     "processor": "test",
                     "cores": 1,
                     "chips": 1,
-                    "memory_gb": -1,
-                    "cpu_freq_mhz": -1
+                    "memory": -1,
+                    "frequency": -1
                 }
 spec = NodeTypeSpec(**spec_values)
 


### PR DESCRIPTION
This PR updates instance list according to latest list for 0.7.11 collected by [kepler-model-training-playbook](https://github.com/sustainable-computing-io/kepler-model-training-playbook). 

Additionally, fix some bugs (pipeline not defined if args.id not defined, attribute name on initialization).

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
