### PR TITLE
make filter pod by benchmark optional

### DIFF
--- a/model_training/cmd_instruction.md
+++ b/model_training/cmd_instruction.md
@@ -1,16 +1,22 @@
 # Manual Metric Collection and Training with Entrypoint
 
 ## 1. Collect metrics
-Without benchmark/pipeline automation, kepler metrics can be collected by `query` function by either one of the following options.
+Without benchmark/pipeline automation, kepler metrics can be collected by `query` function by setting `BENCHMARK`, `PROM_URL`, `COLLECT_ID` and either one of the following time options.
+
+> It is recommend to set BENCHMARK name as a part of the pod name such as `stressng` to filter the validated results. BENCHMARK name will be also used by the TrainerIsolator to filter the target pods. If the BENCHMARK cannot be used to filter the target pods, the validated results will show result from all pods.
+
+```bash
+BENCHMARK= # name of the benchmark (will generate [BENCHMARK].json to save start and end time for reference)
+PROM_URL= # e.g., http://localhost:9090
+COLLECT_ID= # any unique id e.g., machine name
+```
+
 ### 1.1. by defining start time and end time
 
 ```bash
-# value setting
-BENCHMARK= # name of the benchmark (will generate [BENCHMARK].json to save start and end time for reference)
-PROM_URL= # e.g., http://localhost:9090
+# time value setting
 START_TIME= # format date +%Y-%m-%dT%H:%M:%SZ
 END_TIME= # format date +%Y-%m-%dT%H:%M:%SZ
-COLLECT_ID= # any unique id e.g., machine name
 
 # query execution
 DATAPATH=/path/to/workspace python cmd/main.py query --benchmark $BENCHMARK --server $PROM_URL --output kepler_query --start-time $START_TIME --end-time $END_TIME --id $COLLECT_ID
@@ -19,11 +25,8 @@ DATAPATH=/path/to/workspace python cmd/main.py query --benchmark $BENCHMARK --se
 ### 1.2. by defining last interval from the execution time
 
 ```bash
-# value setting
-BENCHMARK= # name of the benchmark (will generate [BENCHMARK].json to save start and end time for reference)
-PROM_URL= # e.g., http://localhost:9090
+# time value setting
 INTERVAL= # in second
-COLLECT_ID= # any unique id e.g., machine name
 
 # query execution
 DATAPATH=/path/to/workspace python cmd/main.py query --benchmark $BENCHMARK --server $PROM_URL --output kepler_query --interval $INTERVAL --id $COLLECT_ID
@@ -47,31 +50,30 @@ DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace python cmd/main.py tra
 ```
 
 ## 3. Export models
-Export function is to archive the model that has an error less than threshold from the trained pipeline and make a report in the format that is ready to push to kepler-model-db.
-
-### 3.1. exporting the trained pipeline with BENCHMARK
-
-The benchmark file is created by CPE operator or by step 1.1. or 1.2..
+Export function is to archive the model that has an error less than threshold from the trained pipeline and make a report in the format that is ready to push to kepler-model-db. To use export function, need to set `EXPORTER_PATH` and `PUBLISHER`, and collect date option.
 
 ```bash
-# value setting
 EXPORT_PATH= # /path/to/kepler-model-db/models
 PUBLISHER= # github account of publisher
+```
 
+### 3.1. extracting collect date from benchmark file
+
+The benchmark file is created by CPE operator or by query function from step 1.
+
+```bash
 # export execution
 # require BENCHMARK from collect step
 # require PIPELINE_NAME from train step
 DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace python cmd/main.py export --benchmark $BENCHMARK --pipeline-name $PIPELINE_NAME -o $EXPORT_PATH --publisher $PUBLISHER --zip=true 
 ```
 
-### 3.2. exporting the trained models without BENCHMARK
+### 3.2. manually set collect-date
 
 If the data is collected by tekton, there is no benchmark file created. Need to manually set `--collect-date` instead of `--benchmark` parameter.
 
 ```bash
-# value setting
-EXPORT_PATH= # /path/to/kepler-model-db/models
-PUBLISHER= # github account of publisher
+# collect date value setting
 COLLECT_DATE= # collect date
 
 # export execution


### PR DESCRIPTION
To avoid misunderstanding from validate function, I make the function to filter the pods by inputting benchmark name to be optional with recommendation in the README file. 


Result with filter:
```
===========================================
 Use benchmark name to filter pod results:

 stressng
                                                               count   >0
scenarioID          query
                    kepler_container_bpf_block_irq_total         527    0
                    kepler_container_bpf_cpu_time_ms_total       527  260
                    kepler_container_bpf_net_rx_irq_total        527  121
                    kepler_container_bpf_net_tx_irq_total        527   58
                    kepler_container_bpf_page_cache_hit_total    527    0
```

Result without filter:
```
============================================
 Present results from all pods:


                                                               count    >0
scenarioID          query
                    kepler_container_bpf_block_irq_total        4046     0
                    kepler_container_bpf_cpu_time_ms_total      4046  3374
                    kepler_container_bpf_net_rx_irq_total       4046  2956
                    kepler_container_bpf_net_tx_irq_total       4046   193
                    kepler_container_bpf_page_cache_hit_total   4046     0
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>