### PR TITLE
apply energy source param on train-model flow

### DIFF
--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -166,6 +166,8 @@ jobs:
               persistentVolumeClaim:
                 claimName: task-pvc
             params:
+            - name: ENERGY_SOURCE
+              value: ${{ inputs.energy_source }}
             - name: MODEL_SERVER_IMAGE
               value: ${{ inputs.model_server_image }}
             - name: PIPELINE_NAME


### PR DESCRIPTION
This PR is to fix the issue in retrain-model workflow: https://github.com/sustainable-computing-io/kepler-model-server/actions/runs/10137095697/job/28026878134.

The issue is that the ENERGY_SOURCE parameter is not used by train target and the default of [original train task](https://github.com/sustainable-computing-io/kepler-model-server/blob/main/model_training/tekton/tasks/original-pipeline-task.yaml) is `acpi,rapl-sysfs`. ec2 does not have acpi source so it throws an error.

Here is result of temporary workflow I tested locally in my repo: https://github.com/sunya-ch/kepler-model-server/actions/runs/10139182692

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
