### PR TITLE
fix: add boto3, spec pipeline version, version export path, and BREAKING CHANGE remove group feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "seaborn==0.13.2",
   "Werkzeug==3.0.3",
   "xgboost==2.1.0",
+  "boto3==1.34.69"
 ]
 
 [project.scripts]

--- a/src/train/specpower_pipeline.py
+++ b/src/train/specpower_pipeline.py
@@ -120,7 +120,7 @@ class SpecPipelineRun():
 
 if __name__ == "__main__":
     spec_db_url = "http://localhost:8080"
-    pipeline_name = "specpower"
+    pipeline_name = "specpower-0.7.11"
     pipelinerun = SpecPipelineRun(name=pipeline_name)
     _, abs_data, dyn_data = pipelinerun.process(spec_db_url)
     pipelinerun.save_metadata()

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -8,5 +8,5 @@ from loader import load_json, load_csv, load_pkl, load_metadata, load_scaler, lo
 from saver import assure_path, save_csv, save_json, save_pkl, save_metadata, save_scaler, save_weight
 from config import getConfig, model_toppath
 from prom_types import get_valid_feature_group_from_queries
-from train_types import SYSTEM_FEATURES, COUNTER_FEAUTRES, CGROUP_FEATURES, BPF_FEATURES, IRQ_FEATURES, WORKLOAD_FEATURES
+from train_types import SYSTEM_FEATURES, COUNTER_FEAUTRES, BPF_FEATURES, IRQ_FEATURES, WORKLOAD_FEATURES
 from train_types import PowerSourceMap, FeatureGroup, FeatureGroups, ModelOutputType, get_feature_group

--- a/src/util/loader.py
+++ b/src/util/loader.py
@@ -315,7 +315,7 @@ def class_to_json(class_obj):
     return json.loads(json.dumps(class_obj.__dict__))
 
 def get_version_path(output_path, assure=True):
-    version_path = os.path.join(output_path, "v{}".format(version))
+    version_path = os.path.join(output_path, "v{}".format(major_version))
     if assure:
         return assure_path(version_path)
     return version_path

--- a/src/util/train_types.py
+++ b/src/util/train_types.py
@@ -15,12 +15,11 @@ from typing import List
 SYSTEM_FEATURES = ["node_info", "cpu_scaling_frequency_hertz"]
 
 COUNTER_FEAUTRES = ["cache_miss", "cpu_cycles", "cpu_instructions"]
-CGROUP_FEATURES = ["cgroupfs_cpu_usage_us", "cgroupfs_memory_usage_bytes", "cgroupfs_system_cpu_usage_us", "cgroupfs_user_cpu_usage_us"]
 BPF_FEATURES = ["bpf_cpu_time_ms", "bpf_page_cache_hit"]
 IRQ_FEATURES = ["bpf_block_irq", "bpf_net_rx_irq", "bpf_net_tx_irq"]
 ACCELERATE_FEATURES = ['accelerator_intel_qat']
-WORKLOAD_FEATURES = COUNTER_FEAUTRES + CGROUP_FEATURES + BPF_FEATURES + IRQ_FEATURES + ACCELERATE_FEATURES
-BASIC_FEATURES = COUNTER_FEAUTRES + CGROUP_FEATURES + BPF_FEATURES 
+WORKLOAD_FEATURES = COUNTER_FEAUTRES + BPF_FEATURES + IRQ_FEATURES + ACCELERATE_FEATURES
+BASIC_FEATURES = COUNTER_FEAUTRES + BPF_FEATURES
 
 PowerSourceMap = {
     "rapl-sysfs": ["package", "core", "uncore", "dram"],
@@ -51,14 +50,13 @@ class FeatureGroup(enum.Enum):
     Full = 1
     WorkloadOnly = 2
     CounterOnly = 3
-    CgroupOnly = 4
-    BPFOnly = 5
-    IRQOnly = 6
-    CounterIRQCombined = 7
-    Basic = 8
-    BPFIRQ = 9
-    AcceleratorOnly = 10
-    ThirdParty = 11
+    BPFOnly = 4
+    IRQOnly = 5
+    CounterIRQCombined = 6
+    Basic = 7
+    BPFIRQ = 8
+    AcceleratorOnly = 9
+    ThirdParty = 10
     Unknown = 99
 
 class EnergyComponentLabelGroup(enum.Enum):
@@ -83,7 +81,6 @@ FeatureGroups = {
     FeatureGroup.Full: deep_sort(WORKLOAD_FEATURES + SYSTEM_FEATURES),
     FeatureGroup.WorkloadOnly: deep_sort(WORKLOAD_FEATURES),
     FeatureGroup.CounterOnly: deep_sort(COUNTER_FEAUTRES),
-    FeatureGroup.CgroupOnly: deep_sort(CGROUP_FEATURES),
     FeatureGroup.BPFOnly: deep_sort(BPF_FEATURES),
     FeatureGroup.BPFIRQ: deep_sort(BPF_FEATURES + IRQ_FEATURES),
     FeatureGroup.CounterIRQCombined: deep_sort(COUNTER_FEAUTRES + IRQ_FEATURES),
@@ -91,7 +88,7 @@ FeatureGroups = {
     FeatureGroup.AcceleratorOnly: deep_sort(ACCELERATE_FEATURES),
 }
 
-SingleSourceFeatures = [FeatureGroup.CounterOnly.name, FeatureGroup.CgroupOnly.name, FeatureGroup.BPFOnly.name, FeatureGroup.BPFIRQ.name]
+SingleSourceFeatures = [FeatureGroup.CounterOnly.name, FeatureGroup.BPFOnly.name, FeatureGroup.BPFIRQ.name]
 
 def is_single_source_feature_group(fg):
     return fg.name in SingleSourceFeatures
@@ -100,7 +97,6 @@ default_main_feature_map = {
     FeatureGroup.Full: "cpu_instructions",
     FeatureGroup.WorkloadOnly: "cpu_instructions",
     FeatureGroup.CounterOnly: "cpu_instructions",
-    FeatureGroup.CgroupOnly: "cgroupfs_cpu_usage_us",
     FeatureGroup.BPFOnly: "bpf_cpu_time_ms",
     FeatureGroup.BPFIRQ: "bpf_cpu_time_ms",
     FeatureGroup.CounterIRQCombined: "cpu_instructions",
@@ -111,7 +107,6 @@ default_dram_feature_map = {
     FeatureGroup.Full: "cache_miss",
     FeatureGroup.WorkloadOnly: "cache_miss",
     FeatureGroup.CounterOnly: "cache_miss",
-    FeatureGroup.CgroupOnly: "cgroupfs_memory_usage_bytes",
     FeatureGroup.BPFOnly: "bpf_page_cache_hit",
     FeatureGroup.BPFIRQ: "bpf_page_cache_hit",
     FeatureGroup.CounterIRQCombined: "cache_miss",

--- a/tests/estimator_model_request_test.py
+++ b/tests/estimator_model_request_test.py
@@ -107,23 +107,23 @@ if __name__ == '__main__':
     if os.path.exists(output_path):
         shutil.rmtree(output_path)
     # valid model
-    os.environ[init_url_key] = get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.CgroupOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)
+    os.environ[init_url_key] = get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.BPFOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)
     print("Requesting from ", os.environ[init_url_key])
-    request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.CgroupOnly], output_type=output_type_name)
+    request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.BPFOnly], output_type=output_type_name)
     data = json.dumps(request_json)
     output = handle_request(data)
     assert len(output['powers']) > 0, "cannot get power {}\n {}".format(output['msg'], request_json)
-    print("result {}/{} from static set: {}".format(output_type_name, FeatureGroup.CgroupOnly.name, output))
+    print("result {}/{} from static set: {}".format(output_type_name, FeatureGroup.BPFOnly.name, output))
     del loaded_model[output_type_name][energy_source]
     # invalid model
     os.environ[init_url_key] = get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.BPFOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)
     print("Requesting from ", os.environ[init_url_key])
-    request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.CgroupOnly], output_type=output_type_name)
+    request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.CounterOnly], output_type=output_type_name)
     data = json.dumps(request_json)
     power_request = json.loads(data, object_hook = lambda d : PowerRequest(**d))
     output_path = get_achived_model(power_request)
     assert output_path is None, "model should be invalid\n {}".format(output_path)
-    os.environ['MODEL_CONFIG'] = "{}=true\n{}={}\n".format(estimator_enable_key,init_url_key,get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.CgroupOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline))
+    os.environ['MODEL_CONFIG'] = "{}=true\n{}={}\n".format(estimator_enable_key,init_url_key,get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.BPFOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline))
     set_env_from_model_config()
     print("Requesting from ", os.environ[init_url_key])
     reset_failed_list()
@@ -132,7 +132,7 @@ if __name__ == '__main__':
     output_path = get_download_output_path(download_path, energy_source, output_type)
     if os.path.exists(output_path):
         shutil.rmtree(output_path)
-    request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.CgroupOnly], output_type=output_type_name)
+    request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.BPFOnly], output_type=output_type_name)
     data = json.dumps(request_json)
     output = handle_request(data)
     assert len(output['powers']) > 0, "cannot get power {}\n {}".format(output['msg'], request_json)

--- a/tests/minimal_trainer.py
+++ b/tests/minimal_trainer.py
@@ -12,7 +12,7 @@ from pipeline_test import process
 from util import FeatureGroup
 
 trainer_names = [ 'GradientBoostingRegressorTrainer', 'SGDRegressorTrainer', 'XgboostFitTrainer' ]
-valid_feature_groups = [ FeatureGroup.BPFOnly, FeatureGroup.CgroupOnly ]
+valid_feature_groups = [ FeatureGroup.BPFOnly ]
 
 if __name__ == '__main__':
     process(target_energy_sources=["acpi", "rapl-sysfs"], abs_trainer_names=trainer_names, dyn_trainer_names=trainer_names, valid_feature_groups=valid_feature_groups)


### PR DESCRIPTION
This PR additionally add missing fixes and updates on bumping to v0.7.11 including removing cgroups feature group as raised in issue https://github.com/sustainable-computing-io/kepler-model-server/issues/262.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>