### PR TITLE
fix: pd.unique warning and ignore file not found

### DIFF
--- a/src/util/extract_types.py
+++ b/src/util/extract_types.py
@@ -1,4 +1,4 @@
-import pandas as pd
+import numpy as np
 
 from prom_types import TIMESTAMP_COL, pkg_id_column
 from train_types import PowerSourceMap
@@ -31,7 +31,7 @@ def ratio_to_col(unit_val):
     return "packge_ratio_{}".format(unit_val)
 
 def get_unit_vals(power_columns):
-    return pd.unique([col_to_unit_val(col) for col in power_columns if "package" in col])
+    return np.unique([col_to_unit_val(col) for col in power_columns if "package" in col])
 
 def get_num_of_unit(energy_source, label_cols):
     energy_components = PowerSourceMap(energy_source)

--- a/src/util/loader.py
+++ b/src/util/loader.py
@@ -64,6 +64,8 @@ def load_pkl(path, name):
     try:
         res = joblib.load(filepath)
         return res
+    except FileNotFoundError:
+        return None
     except Exception as err:
         print("fail to load pkl {}: {}".format(filepath, err))
         return None


### PR DESCRIPTION
fix 

```
FutureWarning: unique with argument that is not not a Series, Index, ExtensionArray, or np.ndarray is deprecated and will raise in a future version.
  return pd.unique([col_to_unit_val(col) for col in power_columns if "package" in col])
```

