### PR TITLE
fix: incompatability of specpower model on 0.7.11

### DIFF
--- a/src/train/specpower_pipeline.py
+++ b/src/train/specpower_pipeline.py
@@ -70,6 +70,8 @@ def get_machine_spec(df):
     if len(df) == 0:
         return NodeTypeSpec()
     data_spec = df.iloc[0].to_dict()
+    data_spec["memory"] = data_spec["memory_gb"]
+    data_spec["frequency"] = data_spec["cpu_freq_mhz"]
     spec = NodeTypeSpec(**data_spec)
     return spec
 

--- a/src/util/loader.py
+++ b/src/util/loader.py
@@ -26,7 +26,7 @@ PREPROCESS_FOLDERNAME = "preprocessed_data"
 default_train_output_pipeline = "std_v{}".format(version)
 default_pipelines = {
     "rapl-sysfs": "ec2-{}".format(version),
-    "acpi": "specpower"
+    "acpi": "specpower-{}".format(version)
 }
 base_model_url = "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v{}".format(major_version)
 def get_pipeline_url(model_topurl, pipeline_name):


### PR DESCRIPTION
- [x] https://github.com/sustainable-computing-io/kepler-model-db/pull/26

As mentioned in https://github.com/sustainable-computing-io/kepler-model-server/issues/339, even if there is no metric name changes but there is incompatibility issue due to sklearn upgrade. This requires training a new pipeline and requires conversion of column names in specpower database. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>