### PR TITLE
doc(tekton): fix tekton release URL

### DIFF
--- a/model_training/tekton/README.md
+++ b/model_training/tekton/README.md
@@ -17,7 +17,7 @@ Previous step: [Prepare cluster](./README.md#1-prepare-cluster)
 1. Install Tekton
 
    ```bash
-   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/0.54.1/release.yaml
+   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.54.1/release.yaml
    ```
 
    > official guideline: <https://tekton.dev/docs/installation/pipelines/>


### PR DESCRIPTION
This commit replaces a non-existent URL for installing Tekton release 0.54.1 with the correct URL.

Fixes #369