### PR TITLE
chore: add integration test with latest

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -234,6 +234,18 @@ jobs:
       kepler_tag: release-0.7.11
       additional_opts: " DB"
 
+  integration-test-with-latest:
+    needs: [check-secret, check-branch, check-change, base-image]
+    if: always()
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      base_change: ${{ needs.check-change.outputs.base }}
+      docker_secret: ${{ needs.check-secret.outputs.docker-secret }}
+      image_repo: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
+      image_tag: ${{ needs.check-branch.outputs.tag }}
+      kepler_tag: latest
+      additional_opts: " DB"
+
   verify_model_training_script:
     runs-on: ubuntu-latest
     steps:

--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -91,7 +91,7 @@ wait_for_keyword() {
         if grep -q "$keyword" <<< $(get_${component}_log); then
             return
         fi
-        sleep 5
+        sleep 10
     done
 
     echo "timeout ${num_iterations}s waiting for '${keyword}' from ${component} log"


### PR DESCRIPTION
In addition to the target next release (currently 0.7.11-release), we should report the compatibility status to the latest version of Kepler.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>