### PR TITLE
fix: apply kepler tag to deploy manifests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -78,6 +78,7 @@ jobs:
           make cleanup
         env:
           OPTS: "ESTIMATOR${{ inputs.additional_opts }}"
+          KEPLER_IMAGE_VERSION: "${{ inputs.kepler_tag }}"
       - name: test deploying with only server
         run: |
           make deploy
@@ -85,6 +86,7 @@ jobs:
           make cleanup
         env:
           OPTS: "SERVER${{ inputs.additional_opts }}"
+          KEPLER_IMAGE_VERSION: "${{ inputs.kepler_tag }}"
       - name: test deploying with estimator and model server
         run: |
           make deploy
@@ -92,3 +94,4 @@ jobs:
           make cleanup
         env:
           OPTS: "ESTIMATOR SERVER${{ inputs.additional_opts }}"
+          KEPLER_IMAGE_VERSION: "${{ inputs.kepler_tag }}"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 export IMAGE_REGISTRY ?= quay.io/sustainable_computing_io
 IMAGE_NAME := kepler_model_server
-IMAGE_VERSION := v0.7
+IMAGE_VERSION := latest
+KEPLER_IMAGE_NAME := kepler
+KEPLER_IMAGE_VERSION := release-0.7.11
 
 IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_VERSION)
+KEPLER_IMAGE ?=  $(IMAGE_REGISTRY)/$(KEPLER_IMAGE_NAME):$(KEPLER_IMAGE_VERSION)
 BASE_IMAGE ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)_base:$(IMAGE_VERSION)
-LATEST_TAG_IMAGE := $(IMAGE_REGISTRY)/$(IMAGE_NAME):latest
 TEST_IMAGE := $(IMAGE)-test
 
 CTR_CMD = docker
@@ -115,6 +117,7 @@ test: \
 set-image:
 	@cd ./manifests/base && kustomize edit set image kepler_model_server=$(IMAGE)
 	@cd ./manifests/server && kustomize edit set image kepler_model_server=$(IMAGE)
+	@cd ./manifests/kepler && kustomize edit set image kepler=$(KEPLER_IMAGE)
 
 # deploy
 _deploy:

--- a/manifests/kepler/kustomization.yaml
+++ b/manifests/kepler/kustomization.yaml
@@ -1,7 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - github.com/sustainable-computing-io/kepler/manifests/k8s/config/base
+- github.com/sustainable-computing-io/kepler/manifests/k8s/config/base
 
 patchesStrategicMerge:
 - ./patch/patch-ci.yaml
+images:
+- name: kepler
+  newName: quay.io/sustainable_computing_io/kepler
+  newTag: release-0.7.11

--- a/manifests/kepler/patch/patch-ci.yaml
+++ b/manifests/kepler/patch/patch-ci.yaml
@@ -17,4 +17,4 @@ spec:
       containers:
       - name: kepler-exporter
         imagePullPolicy: IfNotPresent
-        image: quay.io/sustainable_computing_io/kepler:release-0.7.11
+        image: kepler:latest


### PR DESCRIPTION
This fix the behavior that latest kepler image doesn't apply in integration CI.

integration test with fixed version
```yaml
  Containers:
   kepler-exporter:
    Image:      quay.io/sustainable_computing_io/kepler:release-0.7.11
    Port:       9102/TCP
    Host Port:  0/TCP
    Command:
      /bin/sh
      -c
    Args:
      /usr/bin/kepler -v=4 -redfish-cred-file-path=/etc/redfish/redfish.csv
```

integration test with latest version
```yaml
  Containers:
   kepler-exporter:
    Image:      quay.io/sustainable_computing_io/kepler:latest
    Port:       9102/TCP
    Host Port:  0/TCP
    Command:
      /bin/sh
      -c
    Args:
      /usr/bin/kepler -v=4 -redfish-cred-file-path=/etc/redfish/redfish.csv
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>