### PR TITLE
fix: mismatch model request check (unexpectedly-repeated model request)

### DIFF
--- a/manifests/base/patch/patch-estimator-sidecar.yaml
+++ b/manifests/base/patch/patch-estimator-sidecar.yaml
@@ -6,9 +6,9 @@ metadata:
 data:
   MODEL_CONFIG: |
     NODE_COMPONENTS_ESTIMATOR=true
-    NODE_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/ec2-0.7.11/rapl-sysfs/AbsPower/BPFOnly/GradientBoostingRegressorTrainer_0.zip
+    NODE_COMPONENTS_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/ec2-0.7.11/rapl-sysfs/AbsPower/BPFOnly/SGDRegressorTrainer_0.zip
     NODE_TOTAL_ESTIMATOR=true
-    NODE_TOTAL_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/specpower/acpi/AbsPower/BPFOnly/GradientBoostingRegressorTrainer_0.zip
+    NODE_TOTAL_INIT_URL=https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/specpower-0.7.11/acpi/AbsPower/BPFOnly/SGDRegressorTrainer_0.zip
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/src/kepler_model/estimate/model_server_connector.py
+++ b/src/kepler_model/estimate/model_server_connector.py
@@ -35,8 +35,9 @@ def unpack(energy_source, output_type, response, replace=True):
     tmp_filepath = os.path.join(download_path, TMP_FILE)
     if os.path.exists(output_path):
         if not replace:
-            # delete downloaded file
-            os.remove(tmp_filepath)
+            if os.path.exists(tmp_filepath):
+                # delete downloaded file
+                os.remove(tmp_filepath)
             return output_path
         # delete existing model
         shutil.rmtree(output_path)


### PR DESCRIPTION
This PR fixes the issue found by @sthaha that estimator calls model-request for multiple times. 
The root cause is that the estimator has the logic to check mismatch trainer. Kepler requests for the default trainer which is SGDTrainer but the estimator configmap set URL to GBR. For the case of estimator-only, it will never find the match one since it is statically set.

This PR adds a check whether the model-server is enabled or not before checking the mismatch.

To see the fix, check CI log for estimator-only case.

## Before:
![Screenshot 2024-08-20 at 17 23 34](https://github.com/user-attachments/assets/91f8d1eb-b8e0-4285-81be-c0c2686a11e4)


## After:

![Screenshot 2024-08-20 at 17 21 29](https://github.com/user-attachments/assets/1d032fa2-bd73-4093-883e-db21efd5af32)
