### PR TITLE
fix: missing run in run-collector-client make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,10 @@ run-estimator:
 
 run-collector-client:
 	$(CTR_CMD) exec estimator /bin/bash -c \
-		"while [ ! -S "/tmp/estimator.sock" ]; do sleep 1; done; hatch test -vvv -s ./tests/estimator_power_request_test.py"
+		"while [ ! -S "/tmp/estimator.sock" ]; do \
+			sleep 1; \
+		done; \
+		hatch run test -vvv -s ./tests/estimator_power_request_test.py"
 
 clean-estimator:
 	$(CTR_CMD) stop estimator


### PR DESCRIPTION
```
hatch test -vvv -s ./tests/estimator_power_request_test.py"
     ^ run is missing here
```

