### PR TITLE
chore: print log before stop container and try force remove

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ run-collector-client:
 		"while [ ! -S "/tmp/estimator.sock" ]; do sleep 1; done; hatch test -vvv -s ./tests/estimator_power_request_test.py"
 
 clean-estimator:
-	$(CTR_CMD) stop estimator
+	@$(CTR_CMD) logs estimator
+	@$(CTR_CMD) stop estimator
+	@$(CTR_CMD) rm estimator || true
 
 test-estimator: run-estimator run-collector-client clean-estimator
 
@@ -78,7 +80,9 @@ run-estimator-client:
 		hatch run test -vvv -s ./tests/estimator_model_request_test.py
 
 clean-model-server:
+	@$(CTR_CMD) logs model-server
 	@$(CTR_CMD) stop model-server
+	@$(CTR_CMD) rm model-server || true
 
 test-model-server: \
 	run-model-server \


### PR DESCRIPTION
As mentioned in https://github.com/sustainable-computing-io/kepler-model-server/pull/370/files#r1719183945, this PR separate a commit to print log and try forcefully deleting the container in the case of deletion hang. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>