### PR TITLE
chore(compose): run kepler without power meters

### DIFF
--- a/manifests/compose/dev/compose.yaml
+++ b/manifests/compose/dev/compose.yaml
@@ -13,9 +13,9 @@ services:
       - type: bind
         source: /proc
         target: /proc
-      # - type: bind
-      #   source: /sys
-      #   target: /sys
+      - type: bind
+        source: /sys
+        target: /sys
       - type: bind
         source: ./kepler/etc/kepler
         target: /etc/kepler
@@ -63,6 +63,7 @@ services:
         set -x;
         /usr/bin/kepler \
           -address="0.0.0.0:9100" \
+          -disable-power-meter \
           -v="8"
 
   estimator:


### PR DESCRIPTION
This useful during local development on a BM where we can run kepler without power meter.

Running this locally 
```
❯ dc logs estimator -f
estimator-1  | set NODE_TOTAL_ESTIMATOR to true.
estimator-1  | set NODE_TOTAL_INIT_URL to https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/specpower-0.7.11/acpi/AbsPower/BPFOnly/GradientBoostingRegressorTr
ainer_0.zip.
estimator-1  | set NODE_COMPONENTS_ESTIMATOR to true.
estimator-1  | INFO:kepler_model.estimate.estimator:clean socket
estimator-1  | set NODE_COMPONENTS_INIT_URL to https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/ec2-0.7.11/rapl-sysfs/AbsPower/BPFOnly/GradientBoostingRegres
sorTrainer_0.zip.
estimator-1  | INFO:kepler_model.estimate.estimator:started serving on /tmp/estimator.sock
estimator-1  | INFO:kepler_model.estimate.estimator:load model from model server: /mnt/download/acpi/AbsPower
estimator-1  | INFO:kepler_model.estimate.estimator:set model PolynomialRegressionTrainer_75 for AbsPower (acpi)
estimator-1  | INFO:kepler_model.estimate.estimator:load model from model server: /mnt/download/rapl-sysfs/AbsPower
estimator-1  | INFO:kepler_model.estimate.estimator:set model GradientBoostingRegressorTrainer_2 for AbsPower (rapl-sysfs)

```

Kepler logs 
```
❯ dc logs kepler | ag power
kepler-1  | + /usr/bin/kepler -address=0.0.0.0:9100 -disable-power-meter -v=8
kepler-1  | I0822 03:07:59.686183 1641068 config.go:284] The Idle power will be exposed. Are you running on Baremetal or using single VM per node?
kepler-1  | I0822 03:07:59.686277 1641068 config.go:158] EXPOSE_COMPONENT_POWER: true
kepler-1  | I0822 03:07:59.686287 1641068 config.go:159] EXPOSE_ESTIMATED_IDLE_POWER_METRICS: true. This only impacts when the power is estimated using pre-prained models. Estimated idle power is mean
ingful only when Kepler is running on bare-metal or with a single virtual machine (VM) on the node.
kepler-1  | I0822 03:07:59.686374 1641068 power.go:53] use sysfs to obtain power
kepler-1  | I0822 03:07:59.686924 1641068 acpi.go:71] Could not find any ACPI power meter path. Is it a VM?
kepler-1  | I0822 03:07:59.686935 1641068 power.go:73] using none to obtain power
kepler-1  | I0822 03:08:00.106636 1641068 model.go:179] Model Config PROCESS_TOTAL: {ModelType:Ratio ModelOutputType:DynPower TrainerName: EnergySource:acpi SelectFilter: InitModelURL: InitModelFilepa
th: IsNodePowerModel:false ProcessFeatureNames:[] NodeFeatureNames:[] SystemMetaDataFeatureNames:[] SystemMetaDataFeatureValues:[]}
kepler-1  | I0822 03:08:00.106669 1641068 model.go:92] Using Power Model Ratio
kepler-1  | I0822 03:08:00.106676 1641068 process_energy.go:114] Using the Ratio/DynPower Power Model to estimate Process Platform Power
kepler-1  | I0822 03:08:00.106691 1641068 model.go:179] Model Config PROCESS_COMPONENTS: {ModelType:Ratio ModelOutputType:DynPower TrainerName: EnergySource:intel_rapl SelectFilter: InitModelURL: Init
ModelFilepath: IsNodePowerModel:false ProcessFeatureNames:[] NodeFeatureNames:[] SystemMetaDataFeatureNames:[] SystemMetaDataFeatureValues:[]}
kepler-1  | I0822 03:08:00.106703 1641068 model.go:92] Using Power Model Ratio
kepler-1  | I0822 03:08:00.106713 1641068 process_energy.go:124] Using the Ratio/DynPower Power Model to estimate Process Component Power
kepler-1  | I0822 03:08:00.106739 1641068 model.go:179] Model Config NODE_TOTAL: {ModelType:EstimatorSidecar ModelOutputType:AbsPower TrainerName: EnergySource:acpi SelectFilter: InitModelURL:https://
raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/specpower-0.7.11/acpi/AbsPower/BPFOnly/GradientBoostingRegressorTrainer_0.zip InitModelFilepath: IsNodePowerModel:tr
ue ProcessFeatureNames:[] NodeFeatureNames:[] SystemMetaDataFeatureNames:[] SystemMetaDataFeatureValues:[]}
kepler-1  | I0822 03:08:00.209773 1641068 model.go:146] Using Power Model AbsPower
kepler-1  | I0822 03:08:00.209811 1641068 node_platform_energy.go:52] Using the EstimatorSidecar/AbsPower Power Model to estimate Node Platform Power
kepler-1  | I0822 03:08:00.209975 1641068 model.go:179] Model Config NODE_COMPONENTS: {ModelType:EstimatorSidecar ModelOutputType:AbsPower TrainerName: EnergySource:intel_rapl SelectFilter: InitModelU
RL:https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v0.7/ec2-0.7.11/rapl-sysfs/AbsPower/BPFOnly/GradientBoostingRegressorTrainer_0.zip InitModelFilepath: IsNodePo
werModel:true ProcessFeatureNames:[] NodeFeatureNames:[] SystemMetaDataFeatureNames:[] SystemMetaDataFeatureValues:[]}
kepler-1  | I0822 03:08:00.290623 1641068 model.go:146] Using Power Model AbsPower
kepler-1  | I0822 03:08:00.290637 1641068 node_component_energy.go:56] Using the EstimatorSidecar/AbsPower Power Model to estimate Node Component Power
```

> kepler-1  | I0822 03:07:59.686374 1641068 power.go:53] use sysfs to obtain power
is a bit sus 
