### PR TITLE
feat: add --machine-spec arg to estimator and get_machine_spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ run-estimator:
 		$(TEST_IMAGE) \
 		/bin/bash -c "$(PYTHON) tests/http_server.py & sleep 5 && estimator --log-level debug"
 
+run-estimator-with-test-spec:
+	$(CTR_CMD) run --rm -d --platform linux/amd64 \
+		--name estimator \
+		$(TEST_IMAGE) \
+		/bin/bash -c "estimator --machine-spec tests/data/machine/spec.json"
+
 run-collector-client:
 	$(CTR_CMD) exec estimator /bin/bash -c \
 		"while [ ! -S "/tmp/estimator.sock" ]; do \

--- a/src/kepler_model/estimate/model_server_connector.py
+++ b/src/kepler_model/estimate/model_server_connector.py
@@ -16,21 +16,15 @@ from kepler_model.util.loader import get_download_output_path
 from kepler_model.util.train_types import ModelOutputType
 
 
-# discover_spec: determine node spec in json format (refer to NodeTypeSpec)
-def discover_spec():
-    import psutil
-
-    # TODO: reuse node_type_index/generate_spec with loosen selection
-    cores = psutil.cpu_count(logical=True)
-    spec = {"cores": cores}
-    return spec
-
-
-node_spec = discover_spec()
-
-
-def make_model_request(power_request):
-    return {"metrics": power_request.metrics + power_request.system_features, "output_type": power_request.output_type, "source": power_request.energy_source, "filter": power_request.filter, "trainer_name": power_request.trainer_name, "spec": node_spec}
+def make_model_request(power_request, machine_spec=None):
+    model_request = {"metrics": power_request.metrics + power_request.system_features,
+                     "output_type": power_request.output_type,
+                     "source": power_request.energy_source,
+                     "filter": power_request.filter,
+                     "trainer_name": power_request.trainer_name}
+    if machine_spec is not None:
+        model_request["spec"] = machine_spec
+    return model_request
 
 
 TMP_FILE = "tmp.zip"
@@ -54,10 +48,10 @@ def unpack(energy_source, output_type, response, replace=True):
     return output_path
 
 
-def make_request(power_request):
+def make_request(power_request, machine_spec):
     if not is_model_server_enabled():
         return None
-    model_request = make_model_request(power_request)
+    model_request = make_model_request(power_request, machine_spec)
     output_type = ModelOutputType[power_request.output_type]
     try:
         response = requests.post(get_model_server_req_endpoint(), json=model_request)

--- a/src/kepler_model/util/loader.py
+++ b/src/kepler_model/util/loader.py
@@ -64,13 +64,18 @@ default_trainer_name = "GradientBoostingRegressorTrainer"
 default_node_type = 0
 any_node_type = -1
 default_feature_group = FeatureGroup.BPFOnly
+# need to set as default node_type is not available in latest release DB
+default_init_model_name = {
+    "rapl-sysfs": "GradientBoostingRegressorTrainer_1",
+    "acpi": "XgboostFitTrainer_109"
+}
 
-
-def load_json(path: str, name: str):
-    if name.endswith(".json") is False:
-        name = name + ".json"
-
-    filepath = os.path.join(path, name)
+def load_json(path: str, name: str=""):
+    filepath = path
+    if name:
+        if name.endswith(".json") is False:
+            name = name + ".json"
+        filepath = os.path.join(path, name)
     try:
         with open(filepath) as f:
             res = json.load(f)
@@ -106,7 +111,6 @@ def load_remote_pkl(url_path):
     except Exception as e:
         logger.error(f"failed to load pkl url {url_path}: {e}")
         return None
-
 
 def load_machine_spec(data_path, machine_id):
     machine_spec_path = os.path.join(data_path, MACHINE_SPEC_PATH)

--- a/tests/data/machine/spec.json
+++ b/tests/data/machine/spec.json
@@ -1,0 +1,1 @@
+{"processor": "intel_xeon_platinum_8259cl", "cores": 96, "chips": 2, "memory": 377, "frequency": 3500}

--- a/tests/model_server_test.py
+++ b/tests/model_server_test.py
@@ -1,3 +1,4 @@
+# model_server_test.py requires model-server to run
 import codecs
 import json
 import os
@@ -6,6 +7,7 @@ import shutil
 import requests
 
 from kepler_model.server.model_server import MODEL_SERVER_PORT
+from kepler_model.train.profiler.node_type_index import NodeAttribute, attr_has_value
 from kepler_model.util.config import download_path
 from kepler_model.util.train_types import FeatureGroup, FeatureGroups, ModelOutputType
 
@@ -43,8 +45,31 @@ def get_models():
     response = json.loads(response.text)
     return response
 
+def test_attr_has_value():
+    attrs = dict()
+    non_numerical_test_cases = {
+        "": False,
+        None: False,
+        "some": True
+    }
+    numerical_test_cases = {
+        "": False,
+        None: False,
+        "0": False,
+        0: False,
+        "-1": False,
+        -1: False,
+        "1": True,
+        1: True
+    }
+    for tc, value in non_numerical_test_cases.items():
+        attrs[NodeAttribute.PROCESSOR] = tc
+        assert attr_has_value(attrs, NodeAttribute.PROCESSOR) == value
+    for tc, value in numerical_test_cases.items():
+        attrs[NodeAttribute.CORES] = tc
+        assert attr_has_value(attrs, NodeAttribute.CORES) == value
 
-if __name__ == "__main__":
+def test_model_request():
     models = get_models()
     assert len(models) > 0, "more than one type of output"
     for output_models in models.values():
@@ -75,3 +100,7 @@ if __name__ == "__main__":
     make_request(metrics, output_type, trainer_name=trainer_name, node_type=1, weight=True)
     # with acpi source
     make_request(metrics, output_type, energy_source="acpi", trainer_name=trainer_name, node_type=1, weight=True)
+
+if __name__ == "__main__":
+    test_attr_has_value()
+    test_model_request()


### PR DESCRIPTION
This PR updates kepler-model-server estimator with the same behavior as https://github.com/sustainable-computing-io/kepler/pull/1684.

1. pass --machine-spec file via command arguments

with spec file:
```
INFO:kepler_model.estimate.estimator:clean socket
INFO:kepler_model.estimate.estimator:initialize EstimatorServer with spec={'processor': 'intel_xeon_platinum_8259cl', 'cores': 96, 'chips': 2, 'memory': 377, 'frequency': 3500}
INFO:kepler_model.estimate.estimator:started serving on /tmp/estimator.sock
```
without spec file (auto-generated):
```
INFO:kepler_model.estimate.estimator:clean socket
INFO:kepler_model.estimate.estimator:initialize EstimatorServer with spec={'vendor': 'apple', 'processor': '', 'cores': 8, 'chips': 1, 'memory': 14, 'threads_per_core': 1}
INFO:kepler_model.estimate.estimator:started serving on /tmp/estimator.sock
```
2. add get_machine_spec function
3. add attr_has_value function

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>