### PR TITLE
feat: add machine_spec to metadata

### DIFF
--- a/src/kepler_model/estimate/model_server_connector.py
+++ b/src/kepler_model/estimate/model_server_connector.py
@@ -5,6 +5,7 @@ import shutil
 
 import requests
 
+from kepler_model.server.model_server import ModelListParam
 from kepler_model.util.config import (
     download_path,
     get_model_server_list_endpoint,
@@ -13,7 +14,7 @@ from kepler_model.util.config import (
 )
 from kepler_model.util.loader import get_download_output_path
 from kepler_model.util.train_types import ModelOutputType
-from kepler_model.server.model_server import ModelListParam
+
 
 # discover_spec: determine node spec in json format (refer to NodeTypeSpec)
 def discover_spec():

--- a/src/kepler_model/train/pipeline.py
+++ b/src/kepler_model/train/pipeline.py
@@ -44,6 +44,8 @@ class Pipeline:
         self.metadata["abs_trainers"] = [trainer.__class__.__name__ for trainer in trainers if trainer.node_level]
         self.metadata["dyn_trainers"] = [trainer.__class__.__name__ for trainer in trainers if not trainer.node_level]
         self.metadata["init_time"] = time_to_str(datetime.datetime.utcnow())
+        for trainer in trainers:
+            trainer.set_node_type_index(self.node_collection.node_type_index)
 
     def get_abs_data(self, query_results, energy_components, feature_group, energy_source, aggr):
         extracted_data, power_labels, _, _ = self.extractor.extract(query_results, energy_components, feature_group, energy_source, node_level=True, aggr=aggr)

--- a/src/kepler_model/train/trainer/__init__.py
+++ b/src/kepler_model/train/trainer/__init__.py
@@ -61,6 +61,10 @@ class Trainer(metaclass=ABCMeta):
         self.node_models = dict()
         self.node_scalers = dict()
         self.scaler_type = scaler_type
+        self.node_type_index = dict()
+
+    def set_node_type_index(self, node_type_index):
+        self.node_type_index = node_type_index
 
     def _get_save_path(self, node_type):
         save_path = get_save_path(self.group_path, self.trainer_name, node_type=node_type)
@@ -221,6 +225,8 @@ class Trainer(metaclass=ABCMeta):
         item["output_type"] = self.output_type.name
         item["mae"] = mae
         item["mape"] = mape
+        if node_type in self.node_type_index:
+            item["machine_spec"] = self.node_type_index[node_type].get_json()["attrs"]
         item.update(mae_map)
         item.update(mape_map)
         self.metadata = item


### PR DESCRIPTION
This PR adds machine_spec to metadata on
(i) trainer - add machine_spec from pipeline node_type_index
(ii) model-server  - update loaded model metadata if the machine_spec doesn't exist (old version pipeline)

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>