### PR TITLE
feat: add machine_spec to metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ run-estimator-with-test-spec:
 	$(CTR_CMD) run --rm -d --platform linux/amd64 \
 		--name estimator \
 		$(TEST_IMAGE) \
-		/bin/bash -c "estimator --machine-spec tests/data/machine/spec.json"
+		/bin/bash -c "estimator --machine-spec tests/data/machine/spec.json --log-level debug"
 
 run-collector-client:
 	$(CTR_CMD) exec estimator /bin/bash -c \
@@ -129,7 +129,7 @@ run-model-server-with-db:
 		-p 8100:8100 \
 		--name model-server $(TEST_IMAGE) \
 		model-server
-	while ! docker logs model-server 2>&1 | grep -q 'Running on all'; do \
+	while ! $(CTR_CMD) logs model-server 2>&1 | grep -q 'Running on all'; do \
 		echo "... waiting for model-server to serve";  sleep 5; \
 	done
 

--- a/src/kepler_model/estimate/model/model.py
+++ b/src/kepler_model/estimate/model/model.py
@@ -165,6 +165,10 @@ def load_model(model_path):
         return None
 
     metadata["model_path"] = model_path
+    logger.info(f"load metadata {metadata}")
+    # need to delete machine_spec before load model
+    if "machine_spec" in metadata:
+        del metadata["machine_spec"]
     metadata_str = json.dumps(metadata)
     try:
         model = json.loads(metadata_str, object_hook=lambda d: Model(**d))

--- a/src/kepler_model/train/pipeline.py
+++ b/src/kepler_model/train/pipeline.py
@@ -44,6 +44,8 @@ class Pipeline:
         self.metadata["abs_trainers"] = [trainer.__class__.__name__ for trainer in trainers if trainer.node_level]
         self.metadata["dyn_trainers"] = [trainer.__class__.__name__ for trainer in trainers if not trainer.node_level]
         self.metadata["init_time"] = time_to_str(datetime.datetime.utcnow())
+        for trainer in trainers:
+            trainer.set_node_type_index(self.node_collection.node_type_index)
 
     def get_abs_data(self, query_results, energy_components, feature_group, energy_source, aggr):
         extracted_data, power_labels, _, _ = self.extractor.extract(query_results, energy_components, feature_group, energy_source, node_level=True, aggr=aggr)

--- a/src/kepler_model/train/profiler/node_type_index.py
+++ b/src/kepler_model/train/profiler/node_type_index.py
@@ -156,8 +156,10 @@ class NodeTypeSpec:
     def get_size(self):
         return len(self.members)
 
-    def get_cores(self):
-        return self.attrs[NodeAttribute.CORES]
+    def get_cores(self) -> int:
+        if attr_has_value(self.attrs, NodeAttribute.CORES):
+            return int(self.attrs[NodeAttribute.CORES])
+        return 0
 
     # check the comparing node-type spec is covered by this node-type spec
     def cover(self, compare_spec):

--- a/src/kepler_model/train/trainer/__init__.py
+++ b/src/kepler_model/train/trainer/__init__.py
@@ -61,6 +61,10 @@ class Trainer(metaclass=ABCMeta):
         self.node_models = dict()
         self.node_scalers = dict()
         self.scaler_type = scaler_type
+        self.node_type_index = dict()
+
+    def set_node_type_index(self, node_type_index):
+        self.node_type_index = node_type_index
 
     def _get_save_path(self, node_type):
         save_path = get_save_path(self.group_path, self.trainer_name, node_type=node_type)
@@ -214,6 +218,7 @@ class Trainer(metaclass=ABCMeta):
         save_path = self._get_save_path(node_type)
         model_name, model_file = self._model_filename(node_type)
         item["model_name"] = model_name
+        item["trainer"] = self.trainer_name
         item["model_class"] = self.model_class
         item["model_file"] = model_file
         item["features"] = self.features
@@ -221,6 +226,9 @@ class Trainer(metaclass=ABCMeta):
         item["output_type"] = self.output_type.name
         item["mae"] = mae
         item["mape"] = mape
+        if node_type in self.node_type_index:
+            item["node_type"] = node_type
+            item["machine_spec"] = self.node_type_index[node_type].get_json()["attrs"]
         item.update(mae_map)
         item.update(mape_map)
         self.metadata = item

--- a/tests/estimator_model_request_test.py
+++ b/tests/estimator_model_request_test.py
@@ -7,6 +7,11 @@
 # - kepler-model-server is not connected, but some achived models can be download via URL.
 #   - set sample model and make a dummy valid PowerRequest and another invalid PowerRequest
 #
+# Requires
+# - run `model-server``
+# - run `pytest tests/pipeline_test.py` (run once to get models)
+# - run `MODEL_PATH=$(pwd)/src/kepler_model/models python tests/http_server.py`
+#
 #########################
 # import external modules
 import json
@@ -66,7 +71,7 @@ def test_model_request():
         if url != "":
             print("Download: ", url)
             response = requests.get(url)
-            assert response.status_code == 200, "init url must be set and valid"
+            assert response.status_code == 200, f"init url {url} must be set and valid"
             output_path = get_download_output_path(download_path, energy_source, output_type)
             if output_type_name in loaded_model and energy_source in loaded_model[output_type.name]:
                 del loaded_model[output_type_name][energy_source]


### PR DESCRIPTION
replace https://github.com/sustainable-computing-io/kepler-model-server/pull/404.

This PR adds machine_spec to metadata on
(i) trainer - add machine_spec from pipeline node_type_index
(ii) model-server - update loaded model metadata if the machine_spec doesn't exist (old version pipeline)