### PR TITLE
fix: pass true as string in pipeline param

### DIFF
--- a/model_training/tekton/pipelines/complete-retrain.yaml
+++ b/model_training/tekton/pipelines/complete-retrain.yaml
@@ -58,7 +58,7 @@ spec:
       when:
         - input: $(params.LOAD_DATA)
           operator: in
-          values: [true]
+          values: ["true"]
         - input: $(params.COS_PROVIDER)
           operator: in
           values: [ibmcloud]
@@ -80,7 +80,7 @@ spec:
       when:
         - input: $(params.LOAD_DATA)
           operator: in
-          values: [true]
+          values: ["true"]
         - input: $(params.COS_PROVIDER)
           operator: in
           values: [aws]

--- a/model_training/tekton/pipelines/single-retrain.yaml
+++ b/model_training/tekton/pipelines/single-retrain.yaml
@@ -61,7 +61,7 @@ spec:
       when:
         - input: $(params.LOAD_DATA)
           operator: in
-          values: [true]
+          values: ["true"]
         - input: $(params.COS_PROVIDER)
           operator: in
           values: [ibmcloud]
@@ -83,7 +83,7 @@ spec:
       when:
         - input: $(params.LOAD_DATA)
           operator: in
-          values: [true]
+          values: ["true"]
         - input: $(params.COS_PROVIDER)
           operator: in
           values: [aws]


### PR DESCRIPTION
# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  hatch fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
---

fix the issue from previous merge #429 
Only either string and array is allowed for tekton params. Need to explicitly convert true (bool) to string.

https://github.com/sustainable-computing-io/kepler-model-server/actions/runs/10675504524/job/29587669626