### PR TITLE
feat(ci): Integrate hatch fmt for code formatting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ In addition to approval, the author must confirm the following check list:
 - [ ] Run the following command to format your code:
 
   ```bash
-  hatch fmt
+  make fmt
   ```
 
 - [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,10 @@ jobs:
         shell: bash
         run: |
           make lint
+
+      # run hatch fmt
+      - name: Run formatter using hatch
+        shell: bash
+        run: |
+          make fmt
+          git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ PYTHON  := python3.10
 DOCKERFILES_PATH := ./dockerfiles
 MODEL_PATH := ${PWD}/tests/models
 
+.PHONY: fmt
+fmt:
+	@hatch fmt -f
+
 .PHONY: lint
 lint:
 	@hatch run pymarkdownlnt scan -r .

--- a/model_training/s3/src/s3/loader.py
+++ b/model_training/s3/src/s3/loader.py
@@ -58,7 +58,9 @@ def aws_download(client, bucket_name, machine_id, mnt_path, pipeline_name):
 
 def ibm_download(client, bucket_name, machine_id, mnt_path, pipeline_name):
     print("IBM Download")
-    bucket_file_map = get_bucket_file_map(client, bucket_name, machine_id=machine_id, mnt_path=mnt_path, pipeline_name=pipeline_name, list_func=ibmcloud_list_keys)
+    bucket_file_map = get_bucket_file_map(
+        client, bucket_name, machine_id=machine_id, mnt_path=mnt_path, pipeline_name=pipeline_name, list_func=ibmcloud_list_keys
+    )
     for key, filepath in bucket_file_map.items():
         print(key, filepath)
         dir = os.path.dirname(filepath)

--- a/model_training/s3/src/s3/util.py
+++ b/model_training/s3/src/s3/util.py
@@ -7,7 +7,13 @@ def new_ibm_client(args):
     import ibm_boto3
     from ibm_botocore.client import Config
 
-    cos = ibm_boto3.resource("s3", ibm_api_key_id=args.api_key, ibm_service_instance_id=args.service_instance_id, config=Config(signature_version="oauth"), endpoint_url=args.service_endpoint)
+    cos = ibm_boto3.resource(
+        "s3",
+        ibm_api_key_id=args.api_key,
+        ibm_service_instance_id=args.service_instance_id,
+        config=Config(signature_version="oauth"),
+        endpoint_url=args.service_endpoint,
+    )
     return cos
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-line-length = 320
+line-length = 160
 
 [tool.pytest.ini_options]
 markers = [

--- a/src/kepler_model/cmd/cmd_plot.py
+++ b/src/kepler_model/cmd/cmd_plot.py
@@ -140,7 +140,9 @@ def metadata_plot(args, energy_source, metadata_df, output_folder, name):
             ax = axes
         else:
             ax = axes[i]
-        sns.barplot(data=metadata_df, x="feature_group", y="mae", hue="trainer", ax=ax, hue_order=sorted(metadata_df["trainer"].unique()), errorbar=None, palette="Set3")
+        sns.barplot(
+            data=metadata_df, x="feature_group", y="mae", hue="trainer", ax=ax, hue_order=sorted(metadata_df["trainer"].unique()), errorbar=None, palette="Set3"
+        )
         ax.set_title(component)
         ax.set_ylabel("MAE (Watt)")
         ax.set_xlabel("Feature Group")
@@ -166,7 +168,9 @@ def power_curve_plot(args, data_path, energy_source, output_folder, name):
     node_collection = NodeTypeIndexCollection(pipeline_path)
     all_node_types = sorted(list(node_collection.node_type_index.keys()))
     output_type = ModelOutputType[args.output_type]
-    models, _, cpu_ms_max = _load_all_models(model_toppath=model_toppath, output_type=output_type, name=pipeline_name, node_types=all_node_types, energy_source=energy_source)
+    models, _, cpu_ms_max = _load_all_models(
+        model_toppath=model_toppath, output_type=output_type, name=pipeline_name, node_types=all_node_types, energy_source=energy_source
+    )
     if len(models) > 0:
         _plot_models(models, cpu_ms_max, energy_source, output_folder, name)
 

--- a/src/kepler_model/cmd/cmd_util.py
+++ b/src/kepler_model/cmd/cmd_util.py
@@ -316,7 +316,9 @@ def get_isolator(data_path, isolator, profile, pipeline_name, target_hints, bg_h
         profile_isolator = ProfileBackgroundIsolator(profiles, idle_data)
         supported_isolator[profile_isolator.get_name()] = profile_isolator
         if abs_pipeline_name != "":
-            trainer_isolator = TrainIsolator(idle_data=idle_data, profiler=DefaultProfiler, target_hints=target_hints, bg_hints=bg_hints, abs_pipeline_name=abs_pipeline_name)
+            trainer_isolator = TrainIsolator(
+                idle_data=idle_data, profiler=DefaultProfiler, target_hints=target_hints, bg_hints=bg_hints, abs_pipeline_name=abs_pipeline_name
+            )
             supported_isolator[trainer_isolator.get_name()] = trainer_isolator
     elif abs_pipeline_name != "":
         trainer_isolator = TrainIsolator(target_hints=target_hints, bg_hints=bg_hints, abs_pipeline_name=abs_pipeline_name)
@@ -338,10 +340,32 @@ def get_extractor(extractor):
     return supported_extractor[extractor]
 
 
-def get_pipeline(data_path, pipeline_name, extractor, profile, target_hints, bg_hints, abs_pipeline_name, isolator, abs_trainer_names, dyn_trainer_names, energy_sources, valid_feature_groups, replace_node_type=default_node_type):
+def get_pipeline(
+    data_path,
+    pipeline_name,
+    extractor,
+    profile,
+    target_hints,
+    bg_hints,
+    abs_pipeline_name,
+    isolator,
+    abs_trainer_names,
+    dyn_trainer_names,
+    energy_sources,
+    valid_feature_groups,
+    replace_node_type=default_node_type,
+):
     from kepler_model.train import NewPipeline
 
     isolator = get_isolator(data_path, isolator, profile, pipeline_name, target_hints, bg_hints, abs_pipeline_name, replace_node_type=replace_node_type)
     extractor = get_extractor(extractor)
-    pipeline = NewPipeline(pipeline_name, abs_trainer_names, dyn_trainer_names, extractor=extractor, isolator=isolator, target_energy_sources=energy_sources, valid_feature_groups=valid_feature_groups)
+    pipeline = NewPipeline(
+        pipeline_name,
+        abs_trainer_names,
+        dyn_trainer_names,
+        extractor=extractor,
+        isolator=isolator,
+        target_energy_sources=energy_sources,
+        valid_feature_groups=valid_feature_groups,
+    )
     return pipeline

--- a/src/kepler_model/cmd/main.py
+++ b/src/kepler_model/cmd/main.py
@@ -458,7 +458,20 @@ def train(args):
     pipeline = None
     if args.id:
         machine_id = args.id
-        pipeline = get_pipeline(data_path, pipeline_name, args.extractor, args.profile, args.target_hints, args.bg_hints, args.abs_pipeline_name, args.isolator, abs_trainer_names, dyn_trainer_names, energy_sources, valid_feature_groups)
+        pipeline = get_pipeline(
+            data_path,
+            pipeline_name,
+            args.extractor,
+            args.profile,
+            args.target_hints,
+            args.bg_hints,
+            args.abs_pipeline_name,
+            args.isolator,
+            abs_trainer_names,
+            dyn_trainer_names,
+            energy_sources,
+            valid_feature_groups,
+        )
         machine_spec_json = load_machine_spec(data_path, machine_id)
         if machine_spec_json is not None:
             new_spec = NodeTypeSpec()
@@ -475,7 +488,9 @@ def train(args):
     for energy_source in energy_sources:
         energy_components = PowerSourceMap[energy_source]
         for feature_group in valid_feature_groups:
-            success, abs_data, dyn_data = pipeline.process_multiple_query(input_query_results_list, energy_components, energy_source, feature_group=feature_group.name, replace_node_type=node_type)
+            success, abs_data, dyn_data = pipeline.process_multiple_query(
+                input_query_results_list, energy_components, energy_source, feature_group=feature_group.name, replace_node_type=node_type
+            )
             assert success, f"failed to process pipeline {pipeline.name}"
             for trainer in pipeline.trainers:
                 if trainer.feature_group == feature_group and trainer.energy_source == energy_source:
@@ -488,7 +503,11 @@ def train(args):
             if abs_data is not None:
                 save_csv(data_saved_path, get_general_filename("preprocess", energy_source, feature_group, ModelOutputType.AbsPower, args.extractor), abs_data)
             if dyn_data is not None:
-                save_csv(data_saved_path, get_general_filename("preprocess", energy_source, feature_group, ModelOutputType.DynPower, args.extractor, args.isolator), dyn_data)
+                save_csv(
+                    data_saved_path,
+                    get_general_filename("preprocess", energy_source, feature_group, ModelOutputType.DynPower, args.extractor, args.isolator),
+                    dyn_data,
+                )
 
         print(f"=========== Train {energy_source} Summary ============")
         # save args
@@ -580,7 +599,20 @@ def estimate(args):
             if pipeline_metadata is None:
                 print(f"no metadata for pipeline {pipeline_name}.")
                 continue
-            pipeline = get_pipeline(data_path, pipeline_name, pipeline_metadata["extractor"], args.profile, args.target_hints, args.bg_hints, args.abs_pipeline_name, pipeline_metadata["isolator"], pipeline_metadata["abs_trainers"], pipeline_metadata["dyn_trainers"], energy_sources, valid_fg)
+            pipeline = get_pipeline(
+                data_path,
+                pipeline_name,
+                pipeline_metadata["extractor"],
+                args.profile,
+                args.target_hints,
+                args.bg_hints,
+                args.abs_pipeline_name,
+                pipeline_metadata["isolator"],
+                pipeline_metadata["abs_trainers"],
+                pipeline_metadata["dyn_trainers"],
+                energy_sources,
+                valid_fg,
+            )
             if pipeline is None:
                 print(f"cannot get pipeline {pipeline_name}.")
                 continue
@@ -742,7 +774,16 @@ def plot(args):
                 predicted_power_cols += [predicted_power_colname]
             data_filename = get_general_filename(args.target_data, energy_source, fg, ot, args.extractor, args.isolator)
             # plot prediction
-            ts_plot(data, cols, f"{energy_source} {ot.name} Prediction Result \n by {model_id}", output_folder, f"{data_filename}_{model_id}", subtitles=subtitles, labels=plot_labels, ylabel="Power (W)")
+            ts_plot(
+                data,
+                cols,
+                f"{energy_source} {ot.name} Prediction Result \n by {model_id}",
+                output_folder,
+                f"{data_filename}_{model_id}",
+                subtitles=subtitles,
+                labels=plot_labels,
+                ylabel="Power (W)",
+            )
             # plot correlation to utilization if feature group is set
             if fg is not None:
                 feature_cols = FeatureGroups[fg]
@@ -751,7 +792,17 @@ def plot(args):
                 # plot raw feature data to confirm min-max value
                 ts_plot(data, feature_cols, f"Features {fg}", output_folder, f"{data_filename}_{fg}", labels=None, subtitles=None, ylabel=None)
                 data[feature_cols] = scaler.fit_transform(data[feature_cols])
-                feature_power_plot(data, model_id, ot.name, energy_source, feature_cols, actual_power_cols, predicted_power_cols, output_folder, f"{data_filename}_{model_id}_corr")
+                feature_power_plot(
+                    data,
+                    model_id,
+                    ot.name,
+                    energy_source,
+                    feature_cols,
+                    actual_power_cols,
+                    predicted_power_cols,
+                    output_folder,
+                    f"{data_filename}_{model_id}_corr",
+                )
 
     elif args.target_data == "error":
         from sklearn.preprocessing import MaxAbsScaler
@@ -964,7 +1015,9 @@ def run():
     parser.add_argument("-e", "--energy-source", type=str, help="Specify energy source.", default="rapl-sysfs")
     parser.add_argument("--abs-trainers", type=str, help="Specify trainer names for train command (use comma(,) as delimiter).", default="default")
     parser.add_argument("--dyn-trainers", type=str, help="Specify trainer names for train command (use comma(,) as delimiter).", default="default")
-    parser.add_argument("--trainers", type=str, help="Specify trainer names for train_from_data command (use comma(,) as delimiter).", default="XgboostFitTrainer")
+    parser.add_argument(
+        "--trainers", type=str, help="Specify trainer names for train_from_data command (use comma(,) as delimiter).", default="XgboostFitTrainer"
+    )
 
     # Validate arguments
     parser.add_argument("--benchmark", type=str, help="Specify benchmark file name.")

--- a/src/kepler_model/estimate/archived_model.py
+++ b/src/kepler_model/estimate/archived_model.py
@@ -87,4 +87,3 @@ def get_achived_model(power_request):
             print("cannot validate the archived model")
             return None
     return output_path
-

--- a/src/kepler_model/estimate/estimator.py
+++ b/src/kepler_model/estimate/estimator.py
@@ -42,6 +42,7 @@ class PowerRequest:
 
 loaded_model = dict()
 
+
 def handle_request(data: str, machine_spec=None, discovered_core=None) -> dict:
     try:
         power_request = json.loads(data, object_hook=lambda d: PowerRequest(**d))
@@ -72,7 +73,7 @@ def handle_request(data: str, machine_spec=None, discovered_core=None) -> dict:
                     logger.info(f"try obtaining the requesting trainer {power_request.trainer_name} (current: {current_trainer})")
     if power_request.energy_source not in loaded_model[output_type.name] or mismatch_trainer:
         output_path = get_download_output_path(download_path, power_request.energy_source, output_type)
-        if  mismatch_trainer and os.path.exists(output_path):
+        if mismatch_trainer and os.path.exists(output_path):
             # remove existing model if mismatch
             shutil.rmtree(output_path)
         if not os.path.exists(output_path):
@@ -114,12 +115,13 @@ def handle_request(data: str, machine_spec=None, discovered_core=None) -> dict:
             model_spec = NodeTypeSpec(**metadata["machine_spec"])
             model_cores = model_spec.get_cores()
             if model_cores > 0:
-                core_ratio = discovered_core/model_cores
+                core_ratio = discovered_core / model_cores
             logger.debug(f"model cores: {model_cores}")
         logger.debug(f"metadata: {metadata}")
     response["core_ratio"] = core_ratio
 
     return response
+
 
 class EstimatorServer:
     def __init__(self, socket_path, machine_spec):
@@ -157,6 +159,7 @@ class EstimatorServer:
         y = handle_request(decoded_data, self.machine_spec, self.discovered_core)
         response = json.dumps(y)
         connection.send(response.encode())
+
 
 def clean_socket():
     logger.info("clean socket")

--- a/src/kepler_model/estimate/model/curvefit_model.py
+++ b/src/kepler_model/estimate/model/curvefit_model.py
@@ -25,7 +25,15 @@ class CurveFitModelEstimator:
             self.models = dict()
             model_info = load_model_by_json(model_path, model_file)
             for comp, model_metadata in model_info.items():
-                model = CurveFitModelEstimator(model_path, self.name, self.output_type.name, model_metadata["model_file"], model_metadata["features"], model_metadata["fe_files"], component_init=True)
+                model = CurveFitModelEstimator(
+                    model_path,
+                    self.name,
+                    self.output_type.name,
+                    model_metadata["model_file"],
+                    model_metadata["features"],
+                    model_metadata["fe_files"],
+                    component_init=True,
+                )
                 feature_index = main_feature(self.feauture_group.name, comp)
                 if model.model is not None:
                     model.model.set_feature_index(feature_index)

--- a/src/kepler_model/estimate/model/estimate_common.py
+++ b/src/kepler_model/estimate/model/estimate_common.py
@@ -81,4 +81,3 @@ def compute_error(predicted_power, actual_powers):
             absolute_percentage_errors = np.abs((non_zero_y_test - non_zero_predicted_powers) / non_zero_y_test) * 100
             mape = np.mean(absolute_percentage_errors)
     return mae, mse, mape
-

--- a/src/kepler_model/estimate/model/keras_model.py
+++ b/src/kepler_model/estimate/model/keras_model.py
@@ -18,7 +18,15 @@ class KerasModelEstimator:
             self.models = dict()
             model_info = load_model_by_json(model_path, model_file)
             for comp, model_metadata in model_info.items():
-                model = KerasModelEstimator(model_path, self.name, self.output_type.name, model_metadata["model_file"], model_metadata["features"], model_metadata["fe_files"], component_init=True)
+                model = KerasModelEstimator(
+                    model_path,
+                    self.name,
+                    self.output_type.name,
+                    model_metadata["model_file"],
+                    model_metadata["features"],
+                    model_metadata["fe_files"],
+                    component_init=True,
+                )
                 self.models[comp] = model
         else:
             self.model = load_model_by_keras(model_path, model_file)

--- a/src/kepler_model/estimate/model/scikit_model.py
+++ b/src/kepler_model/estimate/model/scikit_model.py
@@ -20,7 +20,15 @@ class ScikitModelEstimator:
             self.models = dict()
             model_info = load_model_by_json(model_path, model_file)
             for comp, model_metadata in model_info.items():
-                model = ScikitModelEstimator(model_path, self.name, self.output_type.name, model_metadata["model_file"], model_metadata["features"], model_metadata["fe_files"], component_init=True)
+                model = ScikitModelEstimator(
+                    model_path,
+                    self.name,
+                    self.output_type.name,
+                    model_metadata["model_file"],
+                    model_metadata["features"],
+                    model_metadata["fe_files"],
+                    component_init=True,
+                )
                 self.models[comp] = model
         else:
             self.model = load_model_by_pickle(model_path, model_file)

--- a/src/kepler_model/estimate/model/xgboost_model.py
+++ b/src/kepler_model/estimate/model/xgboost_model.py
@@ -23,7 +23,15 @@ class XgboostModelEstimator:
             self.models = dict()
             model_info = load_model_by_json(model_path, model_file)
             for comp, model_metadata in model_info.items():
-                model = XgboostModelEstimator(model_path, self.name, self.output_type.name, model_metadata["model_file"], model_metadata["features"], model_metadata["fe_files"], component_init=True)
+                model = XgboostModelEstimator(
+                    model_path,
+                    self.name,
+                    self.output_type.name,
+                    model_metadata["model_file"],
+                    model_metadata["features"],
+                    model_metadata["fe_files"],
+                    component_init=True,
+                )
                 self.models[comp] = model
         else:
             filepath = os.path.join(model_path, model_file)

--- a/src/kepler_model/estimate/model_server_connector.py
+++ b/src/kepler_model/estimate/model_server_connector.py
@@ -17,11 +17,13 @@ from kepler_model.util.train_types import ModelOutputType
 
 
 def make_model_request(power_request, machine_spec=None):
-    model_request = {"metrics": power_request.metrics + power_request.system_features,
-                     "output_type": power_request.output_type,
-                     "source": power_request.energy_source,
-                     "filter": power_request.filter,
-                     "trainer_name": power_request.trainer_name}
+    model_request = {
+        "metrics": power_request.metrics + power_request.system_features,
+        "output_type": power_request.output_type,
+        "source": power_request.energy_source,
+        "filter": power_request.filter,
+        "trainer_name": power_request.trainer_name,
+    }
     if machine_spec is not None:
         model_request["machine_spec"] = machine_spec
     return model_request
@@ -68,7 +70,7 @@ def list_all_models(energy_source=None, output_type=None, feature_group=None, no
         return dict()
     try:
         endpoint = get_model_server_list_endpoint()
-        params= {}
+        params = {}
         if energy_source:
             params[ModelListParam.EnergySource.value] = energy_source
         if output_type:
@@ -76,7 +78,7 @@ def list_all_models(energy_source=None, output_type=None, feature_group=None, no
         if feature_group:
             params[ModelListParam.FeatureGroup.value] = feature_group
         if node_type:
-           params[ModelListParam.NodeType.value] = node_type
+            params[ModelListParam.NodeType.value] = node_type
         if filter:
             params[ModelListParam.Filter.value] = filter
 

--- a/src/kepler_model/train/ec2_pipeline.py
+++ b/src/kepler_model/train/ec2_pipeline.py
@@ -64,7 +64,14 @@ class Ec2PipelineRun:
     def __init__(self, name, abs_trainer_names=default_trainer_names, dyn_trainer_names=default_trainer_names, isolator=MinIdleIsolator()):
         self.energy_source = "rapl-sysfs"
         self.energy_components = PowerSourceMap[self.energy_source]
-        self.pipeline = NewPipeline(name, abs_trainer_names=abs_trainer_names, dyn_trainer_names=dyn_trainer_names, extractor=DefaultExtractor(), isolator=isolator, target_energy_sources=[self.energy_source])
+        self.pipeline = NewPipeline(
+            name,
+            abs_trainer_names=abs_trainer_names,
+            dyn_trainer_names=dyn_trainer_names,
+            extractor=DefaultExtractor(),
+            isolator=isolator,
+            target_energy_sources=[self.energy_source],
+        )
 
     def process(self):
         for profile in node_profiles:
@@ -113,4 +120,3 @@ if __name__ == "__main__":
     item["endTimeUTC"] = last_modified.strftime("%Y-%m-%dT%H:%M:%SZ")
     print(item)
     save_json(path=data_path, name=pipeline_name, data=item)
-

--- a/src/kepler_model/train/exporter/exporter.py
+++ b/src/kepler_model/train/exporter/exporter.py
@@ -69,4 +69,3 @@ def export(data_path, pipeline_path, db_path, publisher, collect_date, inputs):
     append_version_readme(local_version_path, pipeline_metadata)
 
     return local_export_path
-

--- a/src/kepler_model/train/exporter/validator.py
+++ b/src/kepler_model/train/exporter/validator.py
@@ -33,7 +33,9 @@ class ExportModel:
 
     # assure if version_path is local
     def get_export_path(self, version_path, assure):
-        target_model_path = get_model_group_path(version_path, self.output_type, self.feature_group, self.energy_source, assure=assure, pipeline_name=self.pipeline_name)
+        target_model_path = get_model_group_path(
+            version_path, self.output_type, self.feature_group, self.energy_source, assure=assure, pipeline_name=self.pipeline_name
+        )
         return target_model_path
 
     def export(self, local_version_path):
@@ -112,4 +114,3 @@ def get_validated_export_items(pipeline_path, pipeline_name):
                     valid_rows += [row]
             valid_metadata_df[energy_source][ot.name] = pd.DataFrame(valid_rows)
     return export_items, valid_metadata_df
-

--- a/src/kepler_model/train/exporter/writer.py
+++ b/src/kepler_model/train/exporter/writer.py
@@ -121,7 +121,14 @@ def generate_pipeline_page(version_path, pipeline_metadata, workload_content, sk
 ## Workload information
 
 {}
-    """.format(pipeline_name, pipeline_metadata["extractor"], pipeline_metadata["isolator"], format_trainer(pipeline_metadata["abs_trainers"]), "  (same as AbsPower Trainers)" if pipeline_metadata["abs_trainers"] == pipeline_metadata["dyn_trainers"] else pipeline_metadata["dyn_trainers"], workload_content)
+    """.format(
+        pipeline_name,
+        pipeline_metadata["extractor"],
+        pipeline_metadata["isolator"],
+        format_trainer(pipeline_metadata["abs_trainers"]),
+        "  (same as AbsPower Trainers)" if pipeline_metadata["abs_trainers"] == pipeline_metadata["dyn_trainers"] else pipeline_metadata["dyn_trainers"],
+        workload_content,
+    )
 
     write_markdown(markdown_filepath, markdown_content)
 
@@ -149,10 +156,24 @@ def get_error_dict(remote_version_path, best_model_collection):
             for feature_group_name, best_item in collection[energy_source][output_type_name].items():
                 best_item_with_weight = best_model_collection.get_best_item_with_weight(energy_source, output_type_name, feature_group_name)
                 if best_item is not None:
-                    items += [{"Feature group": feature_group_name, "Model name": best_item.model_name, "MAE": "{:.2f}".format(best_item.metadata["mae"]), "MAPE (%)": "{:.1f}".format(best_item.metadata["mape"]), "URL": best_item.get_archived_filepath(remote_version_path)}]
+                    items += [
+                        {
+                            "Feature group": feature_group_name,
+                            "Model name": best_item.model_name,
+                            "MAE": "{:.2f}".format(best_item.metadata["mae"]),
+                            "MAPE (%)": "{:.1f}".format(best_item.metadata["mape"]),
+                            "URL": best_item.get_archived_filepath(remote_version_path),
+                        }
+                    ]
                 if best_item_with_weight is not None:
                     weight_items += [
-                        {"Feature group": feature_group_name, "Model name": best_item_with_weight.model_name, "MAE": "{:.2f}".format(best_item_with_weight.metadata["mae"]), "MAPE (%)": "{:.1f}".format(best_item_with_weight.metadata["mape"]), "URL": best_item_with_weight.get_weight_filepath(remote_version_path)}
+                        {
+                            "Feature group": feature_group_name,
+                            "Model name": best_item_with_weight.model_name,
+                            "MAE": "{:.2f}".format(best_item_with_weight.metadata["mae"]),
+                            "MAPE (%)": "{:.1f}".format(best_item_with_weight.metadata["mape"]),
+                            "URL": best_item_with_weight.get_weight_filepath(remote_version_path),
+                        }
                     ]
             error_dict[energy_source][output_type_name] = pd.DataFrame(items)
             error_dict_with_weight[energy_source][output_type_name] = pd.DataFrame(weight_items)
@@ -230,7 +251,8 @@ def generate_pipeline_readme(pipeline_name, local_export_path, node_type_index_j
 # append_version_readme - version/README.md
 def append_version_readme(local_version_path, pipeline_metadata):
     readme_path = os.path.join(local_version_path, "README.md")
-    content_to_append = "[{0}](./.doc/{0}.md)|{1}|{2}|[{3}](https://github.com/{3})|[link](./{0})\n".format(pipeline_metadata["name"], pipeline_metadata["collect_time"], pipeline_metadata["last_update_time"], pipeline_metadata["publisher"])
+    content_to_append = "[{0}](./.doc/{0}.md)|{1}|{2}|[{3}](https://github.com/{3})|[link](./{0})\n".format(
+        pipeline_metadata["name"], pipeline_metadata["collect_time"], pipeline_metadata["last_update_time"], pipeline_metadata["publisher"]
+    )
     with open(readme_path, "a") as file:
         file.write(content_to_append)
-

--- a/src/kepler_model/train/isolator/isolator.py
+++ b/src/kepler_model/train/isolator/isolator.py
@@ -65,7 +65,9 @@ def squeeze_data(container_level_data, label_cols):
     # ratio of each energy component for each container
     ratio_columns = [col for col in container_level_data.columns if "ratio" in col]
     # get feature columns
-    feature_columns = [col for col in container_level_data.columns if col not in node_level_columns and col not in ratio_columns and col not in container_indexes]
+    feature_columns = [
+        col for col in container_level_data.columns if col not in node_level_columns and col not in ratio_columns and col not in container_indexes
+    ]
     # sum ratio and feature columns over time
     groupped_sum_data = container_level_data.groupby([TIMESTAMP_COL]).sum()[ratio_columns + feature_columns]
     # re-normalize ratio column
@@ -98,7 +100,9 @@ class MinIdleIsolator(Isolator):
             min = extracted_data[target_cols].min().values.min()
             background_power_colname = get_predicted_background_power_colname(energy_component)
             reconstructed_data[background_power_colname] = min * num_of_unit
-            reconstructed_data[get_reconstructed_power_colname(energy_component)] = data_with_prediction[predicted_colname] + reconstructed_data[background_power_colname]
+            reconstructed_data[get_reconstructed_power_colname(energy_component)] = (
+                data_with_prediction[predicted_colname] + reconstructed_data[background_power_colname]
+            )
         return reconstructed_data
 
     def get_name(self):
@@ -160,7 +164,9 @@ class ProfileBackgroundIsolator(Isolator):
                 predicted_colname = get_predicted_power_colname[energy_source]
                 background_power_colname = get_predicted_background_power_colname(energy_component)
                 reconstructed_data[background_power_colname] = copy_data["profile"] * num_of_unit
-                reconstructed_data[get_reconstructed_power_colname(energy_component)] = data_with_prediction[predicted_colname] + reconstructed_data[background_power_colname]
+                reconstructed_data[get_reconstructed_power_colname(energy_component)] = (
+                    data_with_prediction[predicted_colname] + reconstructed_data[background_power_colname]
+                )
             except Exception as e:
                 print(e)
                 return None
@@ -181,4 +187,3 @@ class NoneIsolator(Isolator):
 
     def get_name(self):
         return "none"
-

--- a/src/kepler_model/train/offline_trainer.py
+++ b/src/kepler_model/train/offline_trainer.py
@@ -84,7 +84,15 @@ class TrainRequest:
         profiles = generate_profiles(idle_profile_map)
         isolator = self.init_isolator(profiler, profiles, idle_data)
         valid_feature_groups = get_valid_feature_group_from_queries(idle_data.keys())
-        self.pipeline = NewPipeline(self.name, self.trainer.abs_trainers, self.trainer.dyn_trainers, extractor=DefaultExtractor(), isolator=isolator, target_energy_sources=[self.energy_source], valid_feature_groups=valid_feature_groups)
+        self.pipeline = NewPipeline(
+            self.name,
+            self.trainer.abs_trainers,
+            self.trainer.dyn_trainers,
+            extractor=DefaultExtractor(),
+            isolator=isolator,
+            target_energy_sources=[self.energy_source],
+            valid_feature_groups=valid_feature_groups,
+        )
 
     def get_model(self):
         self.init_pipeline()

--- a/src/kepler_model/train/online_trainer.py
+++ b/src/kepler_model/train/online_trainer.py
@@ -25,8 +25,24 @@ def initial_pipelines():
     target_energy_sources = PowerSourceMap.keys()
     valid_feature_groups = FeatureGroups.keys()
     profiles = load_all_profiles()
-    profile_pipeline = NewPipeline(default_train_output_pipeline, abs_trainer_names, dyn_trainer_names, extractor=DefaultExtractor(), isolator=ProfileBackgroundIsolator(profiles), target_energy_sources=target_energy_sources, valid_feature_groups=valid_feature_groups)
-    non_profile_pipeline = NewPipeline(default_train_output_pipeline, abs_trainer_names, dyn_trainer_names, extractor=DefaultExtractor(), isolator=MinIdleIsolator(), target_energy_sources=target_energy_sources, valid_feature_groups=valid_feature_groups)
+    profile_pipeline = NewPipeline(
+        default_train_output_pipeline,
+        abs_trainer_names,
+        dyn_trainer_names,
+        extractor=DefaultExtractor(),
+        isolator=ProfileBackgroundIsolator(profiles),
+        target_energy_sources=target_energy_sources,
+        valid_feature_groups=valid_feature_groups,
+    )
+    non_profile_pipeline = NewPipeline(
+        default_train_output_pipeline,
+        abs_trainer_names,
+        dyn_trainer_names,
+        extractor=DefaultExtractor(),
+        isolator=MinIdleIsolator(),
+        target_energy_sources=target_energy_sources,
+        valid_feature_groups=valid_feature_groups,
+    )
     return profile_pipeline, non_profile_pipeline
 
 

--- a/src/kepler_model/train/pipeline.py
+++ b/src/kepler_model/train/pipeline.py
@@ -233,8 +233,20 @@ def initial_trainers(trainer_names, node_level, pipeline_name, target_energy_sou
     return trainers
 
 
-def NewPipeline(pipeline_name, abs_trainer_names, dyn_trainer_names, extractor=DefaultExtractor(), isolator=MinIdleIsolator(), target_energy_sources=PowerSourceMap.keys(), valid_feature_groups=FeatureGroups.keys()):
-    abs_trainers = initial_trainers(abs_trainer_names, node_level=True, pipeline_name=pipeline_name, target_energy_sources=target_energy_sources, valid_feature_groups=valid_feature_groups)
-    dyn_trainers = initial_trainers(dyn_trainer_names, node_level=False, pipeline_name=pipeline_name, target_energy_sources=target_energy_sources, valid_feature_groups=valid_feature_groups)
+def NewPipeline(
+    pipeline_name,
+    abs_trainer_names,
+    dyn_trainer_names,
+    extractor=DefaultExtractor(),
+    isolator=MinIdleIsolator(),
+    target_energy_sources=PowerSourceMap.keys(),
+    valid_feature_groups=FeatureGroups.keys(),
+):
+    abs_trainers = initial_trainers(
+        abs_trainer_names, node_level=True, pipeline_name=pipeline_name, target_energy_sources=target_energy_sources, valid_feature_groups=valid_feature_groups
+    )
+    dyn_trainers = initial_trainers(
+        dyn_trainer_names, node_level=False, pipeline_name=pipeline_name, target_energy_sources=target_energy_sources, valid_feature_groups=valid_feature_groups
+    )
     trainers = abs_trainers + dyn_trainers
     return Pipeline(pipeline_name, trainers, extractor, isolator)

--- a/src/kepler_model/train/profiler/profiler.py
+++ b/src/kepler_model/train/profiler/profiler.py
@@ -184,7 +184,11 @@ class Profile:
         return self.profile[source][component][min_watt_key]
 
     def print_profile(self):
-        print("Profile (node type={}): \n Available energy components: {}\n Available maxabs scalers: {}".format(self.node_type, [f"{key}/{list(self.profile[key].keys())}" for key in self.profile.keys()], self.max_scaler.keys()))
+        print(
+            "Profile (node type={}): \n Available energy components: {}\n Available maxabs scalers: {}".format(
+                self.node_type, [f"{key}/{list(self.profile[key].keys())}" for key in self.profile.keys()], self.max_scaler.keys()
+            )
+        )
 
 
 def generate_profiles(profile_map):

--- a/src/kepler_model/train/prom/prom_query.py
+++ b/src/kepler_model/train/prom/prom_query.py
@@ -42,4 +42,3 @@ class PrometheusClient:
 
     def snapshot_query_result(self):
         return {metric: data for metric, data in self.latest_query_result.items() if len(data) > 0}
-

--- a/src/kepler_model/train/specpower_pipeline.py
+++ b/src/kepler_model/train/specpower_pipeline.py
@@ -73,7 +73,15 @@ class SpecPipelineRun:
         self.power_labels = [acpi_label]
         self.energy_source = platform_energy_source
         # extractor is not used
-        self.pipeline = NewPipeline(name, abs_trainer_names=abs_trainer_names, dyn_trainer_names=dyn_trainer_names, extractor=DefaultExtractor(), isolator=isolator, target_energy_sources=[self.energy_source], valid_feature_groups=[self.feature_group])
+        self.pipeline = NewPipeline(
+            name,
+            abs_trainer_names=abs_trainer_names,
+            dyn_trainer_names=dyn_trainer_names,
+            extractor=DefaultExtractor(),
+            isolator=isolator,
+            target_energy_sources=[self.energy_source],
+            valid_feature_groups=[self.feature_group],
+        )
 
     def load_spec_data(self, spec_db_url):
         spec_extracted_data = dict()

--- a/src/kepler_model/train/trainer/ExponentialRegressionTrainer/main.py
+++ b/src/kepler_model/train/trainer/ExponentialRegressionTrainer/main.py
@@ -24,4 +24,3 @@ class ExponentialRegressionTrainer(CurveFitTrainer):
 
     def init_model(self):
         return CurveFitModel(expo_func, p0_func=p0_func)
-

--- a/src/kepler_model/train/trainer/GradientBoostingRegressorTrainer/main.py
+++ b/src/kepler_model/train/trainer/GradientBoostingRegressorTrainer/main.py
@@ -12,4 +12,3 @@ class GradientBoostingRegressorTrainer(ScikitTrainer):
 
     def init_model(self):
         return GradientBoostingRegressor(n_estimators=100, max_depth=3, learning_rate=0.1)
-

--- a/src/kepler_model/train/trainer/KNeighborsRegressorTrainer/main.py
+++ b/src/kepler_model/train/trainer/KNeighborsRegressorTrainer/main.py
@@ -12,4 +12,3 @@ class KNeighborsRegressorTrainer(ScikitTrainer):
 
     def init_model(self):
         return KNeighborsRegressor(n_neighbors=6)
-

--- a/src/kepler_model/train/trainer/LinearRegressionTrainer/main.py
+++ b/src/kepler_model/train/trainer/LinearRegressionTrainer/main.py
@@ -12,4 +12,3 @@ class LinearRegressionTrainer(ScikitTrainer):
 
     def init_model(self):
         return LinearRegression(positive=True)
-

--- a/src/kepler_model/train/trainer/LogarithmicRegressionTrainer/main.py
+++ b/src/kepler_model/train/trainer/LogarithmicRegressionTrainer/main.py
@@ -22,4 +22,3 @@ class LogarithmicRegressionTrainer(CurveFitTrainer):
 
     def init_model(self):
         return CurveFitModel(log_func, p0_func=p0_func)
-

--- a/src/kepler_model/train/trainer/PolynomialRegressionTrainer/main.py
+++ b/src/kepler_model/train/trainer/PolynomialRegressionTrainer/main.py
@@ -15,4 +15,3 @@ class PolynomialRegressionTrainer(ScikitTrainer):
 
     def init_model(self):
         return LinearRegression()
-

--- a/src/kepler_model/train/trainer/SGDRegressorTrainer/main.py
+++ b/src/kepler_model/train/trainer/SGDRegressorTrainer/main.py
@@ -10,4 +10,3 @@ class SGDRegressorTrainer(ScikitTrainer):
 
     def init_model(self):
         return SGDRegressor(max_iter=1000)
-

--- a/src/kepler_model/train/trainer/SVRRegressorTrainer/main.py
+++ b/src/kepler_model/train/trainer/SVRRegressorTrainer/main.py
@@ -12,4 +12,3 @@ class SVRRegressorTrainer(ScikitTrainer):
 
     def init_model(self):
         return SVR(C=1.0, epsilon=0.2)
-

--- a/src/kepler_model/train/trainer/XGBoostTrainer/main.py
+++ b/src/kepler_model/train/trainer/XGBoostTrainer/main.py
@@ -76,7 +76,9 @@ class XGBoostRegressionStandalonePipeline:
         # results can be used directly by extractor.py
         extractor = DefaultExtractor()
         # Train all models with extractor
-        extracted_data, _, _, _ = extractor.extract(results, self.energy_components_labels, self.feature_group.name, self.energy_source, node_level=self.node_level)
+        extracted_data, _, _, _ = extractor.extract(
+            results, self.energy_components_labels, self.feature_group.name, self.energy_source, node_level=self.node_level
+        )
 
         if extracted_data is not None:
             clean_df = self._generate_clean_model_training_data(extracted_data)
@@ -162,7 +164,9 @@ class XGBoostRegressionModelGenerationPipeline:
             with open(os.path.join(filename_path, self.model_desc)) as f:
                 json_data = json.load(f)
             if json_data["feature_names"] != self.feature_names or json_data["label_names"] != self.label_names:
-                raise XGBoostModelFeatureOrLabelIncompatabilityException(json_data["feature_names"], json_data["label_names"], self.feature_names, self.label_names)
+                raise XGBoostModelFeatureOrLabelIncompatabilityException(
+                    json_data["feature_names"], json_data["label_names"], self.feature_names, self.label_names
+                )
             return new_model, json_data
         return None, None
 
@@ -320,4 +324,3 @@ class XGBoostRegressionModelGenerationPipeline:
                 predicted_results.append(predicted_result.astype(float)[0])
             return predicted_results, retrieved_model_desc
         return None, None
-

--- a/src/kepler_model/train/trainer/__init__.py
+++ b/src/kepler_model/train/trainer/__init__.py
@@ -256,7 +256,11 @@ class Trainer(metaclass=ABCMeta):
         model_dict = dict()
         for component in self.energy_components:
             component_save_file = self.component_model_filename(component)
-            model_dict[component] = {"model_file": component_save_file, "features": self.features, "fe_files": [scaler_filename] + ([] if not hasattr(self, "fe_files") else self.fe_files)}
+            model_dict[component] = {
+                "model_file": component_save_file,
+                "features": self.features,
+                "fe_files": [scaler_filename] + ([] if not hasattr(self, "fe_files") else self.fe_files),
+            }
             # save component model
             self.save_model(save_path, node_type, component)
         # save model dict
@@ -315,4 +319,3 @@ class Trainer(metaclass=ABCMeta):
             item["node_type"] = node_type
             items += [item]
         return pd.DataFrame(items)
-

--- a/src/kepler_model/train/trainer/curvefit.py
+++ b/src/kepler_model/train/trainer/curvefit.py
@@ -125,6 +125,11 @@ class CurveFitTrainer(Trainer):
 
         for component, model in self.node_models[node_type].items():
             scaler = self.node_scalers[node_type]
-            weight_dict[component] = {"All_Weights": {"Categorical_Variables": dict(), "Numerical_Variables": {self.features[i]: {"scale": scaler.scale_[i]} for i in range(len(self.features))}, "CurveFit_Weights": list(model.popt)}}
+            weight_dict[component] = {
+                "All_Weights": {
+                    "Categorical_Variables": dict(),
+                    "Numerical_Variables": {self.features[i]: {"scale": scaler.scale_[i]} for i in range(len(self.features))},
+                    "CurveFit_Weights": list(model.popt),
+                }
+            }
         return weight_dict
-

--- a/src/kepler_model/train/trainer/scikit.py
+++ b/src/kepler_model/train/trainer/scikit.py
@@ -78,7 +78,12 @@ class ScikitTrainer(Trainer):
 
         for component, model in self.node_models[node_type].items():
             scaler = self.node_scalers[node_type]
-            if not hasattr(model, "intercept_") or not hasattr(model, "coef_") or len(model.coef_) != len(self.features) or (hasattr(model.intercept_, "__len__") and len(model.intercept_) != 1):
+            if (
+                not hasattr(model, "intercept_")
+                or not hasattr(model, "coef_")
+                or len(model.coef_) != len(self.features)
+                or (hasattr(model.intercept_, "__len__") and len(model.intercept_) != 1)
+            ):
                 return None
             else:
                 if isinstance(model.intercept_, np.float64):
@@ -104,4 +109,3 @@ class ScikitTrainer(Trainer):
                     }
                 }
         return weight_dict
-

--- a/src/kepler_model/train/trainer/xgboost_interface.py
+++ b/src/kepler_model/train/trainer/xgboost_interface.py
@@ -105,6 +105,11 @@ class XgboostTrainer(Trainer):
                 return
             with open(filename) as f:
                 contents = f.read()
-            weight_dict[component] = {"All_Weights": {"Categorical_Variables": dict(), "Numerical_Variables": {self.features[i]: {"scale": scaler.scale_[i]} for i in range(len(self.features))}, "XGboost_Weights": base64.b64encode(contents.encode("utf-8")).decode("utf-8")}}
+            weight_dict[component] = {
+                "All_Weights": {
+                    "Categorical_Variables": dict(),
+                    "Numerical_Variables": {self.features[i]: {"scale": scaler.scale_[i]} for i in range(len(self.features))},
+                    "XGboost_Weights": base64.b64encode(contents.encode("utf-8")).decode("utf-8"),
+                }
+            }
         return weight_dict
-

--- a/src/kepler_model/util/config.py
+++ b/src/kepler_model/util/config.py
@@ -153,14 +153,27 @@ def get_init_model_url(energy_source, output_type, model_topurl=model_topurl):
         if get_energy_source(prefix) == energy_source:
             modelURL = get_init_url(prefix)
             print("get init url", modelURL)
-            url = get_url(feature_group=FeatureGroup.BPFOnly, output_type=ModelOutputType[output_type], energy_source=energy_source, model_topurl=model_topurl, pipeline_name=pipeline_name)
+            url = get_url(
+                feature_group=FeatureGroup.BPFOnly,
+                output_type=ModelOutputType[output_type],
+                energy_source=energy_source,
+                model_topurl=model_topurl,
+                pipeline_name=pipeline_name,
+            )
             if modelURL == "" and is_output_type_supported(output_type):
                 if energy_source in default_init_model_name:
                     model_name = default_init_model_name[energy_source]
-                    modelURL = get_url(feature_group=FeatureGroup.BPFOnly, output_type=ModelOutputType[output_type], energy_source=energy_source, model_topurl=model_topurl, pipeline_name=pipeline_name, model_name=model_name)
+                    modelURL = get_url(
+                        feature_group=FeatureGroup.BPFOnly,
+                        output_type=ModelOutputType[output_type],
+                        energy_source=energy_source,
+                        model_topurl=model_topurl,
+                        pipeline_name=pipeline_name,
+                        model_name=model_name,
+                    )
                     if url:
                         response = requests.get(url)
-                        if response.status_code== 200:
+                        if response.status_code == 200:
                             modelURL = url
                 print(f"init URL is not set, use {modelURL}")
             return modelURL

--- a/src/kepler_model/util/extract_types.py
+++ b/src/kepler_model/util/extract_types.py
@@ -49,4 +49,3 @@ def get_expected_power_columns(energy_components, num_of_unit=1):
     # TODO: if ratio applied,
     # return [component_to_col(component, "package", unit_val) for component in energy_components for unit_val in range(0,num_of_unit)]
     return [component_to_col(component) for component in energy_components]
-

--- a/src/kepler_model/util/format.py
+++ b/src/kepler_model/util/format.py
@@ -10,7 +10,7 @@ def print_bounded_multiline_message(input_lines, maxlength=200):
             lines += [line]
 
     max_line_length = max(len(line) for line in lines)
-    border = '#' * (max_line_length + 4)
+    border = "#" * (max_line_length + 4)
     print(border)
 
     for line in lines:
@@ -18,6 +18,7 @@ def print_bounded_multiline_message(input_lines, maxlength=200):
         print(formatted_line)
 
     print(border)
+
 
 from datetime import datetime
 

--- a/src/kepler_model/util/loader.py
+++ b/src/kepler_model/util/loader.py
@@ -35,10 +35,7 @@ PREPROCESS_FOLDERNAME = "preprocessed_data"
 
 ## default_train_output_pipeline: a default pipeline name which is output from the training pipeline
 default_train_output_pipeline = f"std_v{version}"
-default_pipelines = {
-    "rapl-sysfs": f"ec2-{version}",
-    "acpi": f"specpower-{version}"
-}
+default_pipelines = {"rapl-sysfs": f"ec2-{version}", "acpi": f"specpower-{version}"}
 base_model_url = f"https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/models/v{major_version}"
 
 
@@ -65,12 +62,10 @@ default_node_type = 0
 any_node_type = -1
 default_feature_group = FeatureGroup.BPFOnly
 # need to set as default node_type is not available in latest release DB
-default_init_model_name = {
-    "rapl-sysfs": "GradientBoostingRegressorTrainer_1",
-    "acpi": "XgboostFitTrainer_109"
-}
+default_init_model_name = {"rapl-sysfs": "GradientBoostingRegressorTrainer_1", "acpi": "XgboostFitTrainer_109"}
 
-def load_json(path: str, name: str=""):
+
+def load_json(path: str, name: str = ""):
     filepath = path
     if name:
         if name.endswith(".json") is False:
@@ -112,17 +107,19 @@ def load_remote_pkl(url_path):
         logger.error(f"failed to load pkl url {url_path}: {e}")
         return None
 
+
 def load_remote_json(url_path):
     if ".json" not in url_path:
         url_path = url_path + ".json"
     try:
         response = urlopen(url_path)
-        response_data = response.read().decode('utf-8')
+        response_data = response.read().decode("utf-8")
         json_data = json.loads(response_data)
         return json_data
     except Exception as e:
         logger.error(f"failed to load json url {url_path}: {e}")
         return None
+
 
 def load_machine_spec(data_path, machine_id):
     machine_spec_path = os.path.join(data_path, MACHINE_SPEC_PATH)
@@ -228,6 +225,7 @@ def is_matched_type(nodeCollection, spec, pipeline_name, model_name, node_type, 
             return True
     return False
 
+
 # get_largest_candidates return list of model_names that have maximum number of cores
 def get_largest_candidates(model_names, pipeline_name, nodeCollection, energy_source):
     pipeline_name = assure_pipeline_name(pipeline_name, energy_source, nodeCollection)
@@ -306,7 +304,9 @@ def list_pipelines(model_toppath, energy_source, model_type):
 def list_all_abs_models(model_toppath, energy_source, valid_fgs, pipeline_name):
     abs_models_map = dict()
     for fg in valid_fgs:
-        group_path = get_model_group_path(model_toppath, output_type=ModelOutputType.AbsPower, feature_group=fg, energy_source=energy_source, pipeline_name=pipeline_name, assure=False)
+        group_path = get_model_group_path(
+            model_toppath, output_type=ModelOutputType.AbsPower, feature_group=fg, energy_source=energy_source, pipeline_name=pipeline_name, assure=False
+        )
         model_names = list_model_names(group_path)
         abs_models_map[group_path] = model_names
     return abs_models_map
@@ -315,7 +315,9 @@ def list_all_abs_models(model_toppath, energy_source, valid_fgs, pipeline_name):
 def list_all_dyn_models(model_toppath, energy_source, valid_fgs, pipeline_name):
     dyn_models_map = dict()
     for fg in valid_fgs:
-        group_path = get_model_group_path(model_toppath, output_type=ModelOutputType.DynPower, feature_group=fg, energy_source=energy_source, pipeline_name=pipeline_name, assure=False)
+        group_path = get_model_group_path(
+            model_toppath, output_type=ModelOutputType.DynPower, feature_group=fg, energy_source=energy_source, pipeline_name=pipeline_name, assure=False
+        )
         model_names = list_model_names(group_path)
         dyn_models_map[group_path] = model_names
     return dyn_models_map
@@ -334,7 +336,14 @@ def _get_metadata_df(group_path):
 
 
 def get_metadata_df(model_toppath, model_type, fg, energy_source, pipeline_name):
-    group_path = get_model_group_path(model_toppath, output_type=ModelOutputType[model_type], feature_group=FeatureGroup[fg], energy_source=energy_source, pipeline_name=pipeline_name, assure=False)
+    group_path = get_model_group_path(
+        model_toppath,
+        output_type=ModelOutputType[model_type],
+        feature_group=FeatureGroup[fg],
+        energy_source=energy_source,
+        pipeline_name=pipeline_name,
+        assure=False,
+    )
     metadata_df = _get_metadata_df(group_path)
     if len(metadata_df) > 0:
         metadata_df[["trainer", "node_type"]] = metadata_df["model_name"].str.split("_", n=1, expand=True)
@@ -374,10 +383,22 @@ def get_download_output_path(download_path, energy_source, output_type) -> str:
     return os.path.join(energy_source_path, output_type.name)
 
 
-def get_url(output_type, feature_group, energy_source, trainer_name=default_trainer_name, node_type=default_node_type, model_topurl=base_model_url, pipeline_name=None, model_name=None, weight=False):
+def get_url(
+    output_type,
+    feature_group,
+    energy_source,
+    trainer_name=default_trainer_name,
+    node_type=default_node_type,
+    model_topurl=base_model_url,
+    pipeline_name=None,
+    model_name=None,
+    weight=False,
+):
     if pipeline_name is None:
         pipeline_name = default_pipelines[energy_source]
-    group_path = get_model_group_path(model_topurl, output_type=output_type, feature_group=feature_group, energy_source=energy_source, pipeline_name=pipeline_name, assure=False)
+    group_path = get_model_group_path(
+        model_topurl, output_type=output_type, feature_group=feature_group, energy_source=energy_source, pipeline_name=pipeline_name, assure=False
+    )
     if model_name is None:
         model_name = get_model_name(trainer_name, node_type)
     file_ext = ".zip"

--- a/src/kepler_model/util/saver.py
+++ b/src/kepler_model/util/saver.py
@@ -3,76 +3,90 @@ import os
 
 import joblib
 
-METADATA_FILENAME = 'metadata'
-SCALER_FILENAME = 'scaler'
-WEIGHT_FILENAME = 'weight'
-TRAIN_ARGS_FILENAME = 'train_arguments'
-NODE_TYPE_INDEX_FILENAME = 'node_type_index'
+METADATA_FILENAME = "metadata"
+SCALER_FILENAME = "scaler"
+WEIGHT_FILENAME = "weight"
+TRAIN_ARGS_FILENAME = "train_arguments"
+NODE_TYPE_INDEX_FILENAME = "node_type_index"
 
 MACHINE_SPEC_PATH = "machine_spec"
+
 
 def _pipeline_model_metadata_filename(energy_source, model_type):
     return f"{energy_source}_{model_type}_model_metadata"
 
+
 def _power_curve_filename(energy_source, model_type):
     return f"{energy_source}_{model_type}_power_curve"
 
+
 def assure_path(path):
-    if path == '':
-        return ''
+    if path == "":
+        return ""
     if not os.path.exists(path):
         os.makedirs(path, exist_ok=True)
     return path
 
+
 def save_json(path, name, data):
-    if '.json' not in name:
-        name = name + '.json'
+    if ".json" not in name:
+        name = name + ".json"
     assure_path(path)
     filename = os.path.join(path, name)
     with open(filename, "w") as f:
         json.dump(data, f)
     return name
 
+
 def save_pkl(path, name, data):
-    if '.pkl' not in name:
-        name = name + '.pkl'
+    if ".pkl" not in name:
+        name = name + ".pkl"
     assure_path(path)
     filename = os.path.join(path, name)
     joblib.dump(data, filename)
     return name
 
+
 def save_csv(path, name, data):
-    if '.csv' not in name:
-        name = name + '.csv'
+    if ".csv" not in name:
+        name = name + ".csv"
     assure_path(path)
     filename = os.path.join(path, name)
     data.to_csv(filename)
     return name
+
 
 def save_machine_spec(data_path, machine_id, spec):
     machine_spec_path = os.path.join(data_path, MACHINE_SPEC_PATH)
     assure_path(machine_spec_path)
     save_json(machine_spec_path, machine_id, spec.get_json())
 
+
 def save_node_type_index(pipeline_path, node_type_index):
     return save_json(pipeline_path, NODE_TYPE_INDEX_FILENAME, node_type_index)
+
 
 def save_metadata(model_path, metadata):
     return save_json(model_path, METADATA_FILENAME, metadata)
 
+
 def save_train_args(pipeline_path, args):
     return save_json(pipeline_path, TRAIN_ARGS_FILENAME, args)
+
 
 def save_scaler(model_path, scaler):
     return save_pkl(model_path, SCALER_FILENAME, scaler)
 
+
 def save_weight(model_path, weight):
     return save_json(model_path, WEIGHT_FILENAME, weight)
+
 
 def save_pipeline_metadata(pipeline_path, pipeline_metadata, energy_source, model_type, metadata_df):
     save_metadata(pipeline_path, pipeline_metadata)
     pipeline_model_metadata_filename = _pipeline_model_metadata_filename(energy_source, model_type)
     return save_csv(pipeline_path, pipeline_model_metadata_filename, metadata_df)
+
 
 def save_profile(profile_path, source, profile):
     profile_filename = os.path.join(profile_path, source + ".json")

--- a/src/kepler_model/util/similarity.py
+++ b/src/kepler_model/util/similarity.py
@@ -12,14 +12,16 @@ similarity_reference = {
 
 similarity_total_weight = sum(similarity_reference.values())
 
-def get_similarity_weight(attr):
-    return similarity_reference[attr]/similarity_total_weight
 
-def compute_jaccard_similarity(str1 :str, str2: str) -> float:
-    if str1.lower() == str2.lower(): # including the case of both are empty
+def get_similarity_weight(attr):
+    return similarity_reference[attr] / similarity_total_weight
+
+
+def compute_jaccard_similarity(str1: str, str2: str) -> float:
+    if str1.lower() == str2.lower():  # including the case of both are empty
         return 1
-    if len(str1) == 0 or len(str2)==0:
-       return 0
+    if len(str1) == 0 or len(str2) == 0:
+        return 0
     set1 = set(str1.lower())  # Convert to lowercase for case-insensitive comparison
     set2 = set(str2.lower())
 
@@ -29,19 +31,22 @@ def compute_jaccard_similarity(str1 :str, str2: str) -> float:
     similarity = intersection / union * 0.5
     return similarity
 
-def compute_similarity(base : float, cmp: float) -> float:
+
+def compute_similarity(base: float, cmp: float) -> float:
     base = float(base)
     cmp = float(cmp)
     diff_ratio = 0
     if base > 0 or cmp > 0:
-        diff_ratio = abs(cmp-base)/((base+cmp)/2)
+        diff_ratio = abs(cmp - base) / ((base + cmp) / 2)
     if diff_ratio >= 1:
         return 0
     else:
-        return 1-diff_ratio
+        return 1 - diff_ratio
+
 
 def compute_looseness(similarity):
-    return 1-similarity
+    return 1 - similarity
+
 
 # get_candidate_score returns certainty
 def get_candidate_score(candidate_uncertain_attribute_freq, candidate_uncertain_attribute_total):
@@ -56,8 +61,9 @@ def get_candidate_score(candidate_uncertain_attribute_freq, candidate_uncertain_
             candidate_freq = candidate[1]
             if candidate_index not in candidate_score:
                 candidate_score[candidate_index] = 0
-            candidate_score[candidate_index] += float(candidate_freq)/total
+            candidate_score[candidate_index] += float(candidate_freq) / total
     return candidate_score
+
 
 def find_best_candidate(candidate_score):
     max_score = 0
@@ -68,11 +74,13 @@ def find_best_candidate(candidate_score):
             max_score = score
     return best_candidate_index, max_score
 
+
 def compute_uncertainty(max_score, num_of_none):
     if num_of_none == 0:
-        return 0 # covered
-    uncertainty = 1 - max_score/num_of_none
+        return 0  # covered
+    uncertainty = 1 - max_score / num_of_none
     return uncertainty
+
 
 def get_num_of_none(in_spec):
     num_of_none = 0

--- a/src/kepler_model/util/train_types.py
+++ b/src/kepler_model/util/train_types.py
@@ -26,7 +26,7 @@ PowerSourceMap = {
     "acpi": ["platform"],
     "hmc": ["platform"],
     "redfish": ["platform"],
-    "trained_power_model": ["package", "core", "uncore", "dram"]
+    "trained_power_model": ["package", "core", "uncore", "dram"],
 }
 
 PACKAGE_ENERGY_COMPONENT_LABEL = ["package"]
@@ -34,12 +34,19 @@ DRAM_ENERGY_COMPONENT_LABEL = ["dram"]
 CORE_ENERGY_COMPONENT_LABEL = ["core"]
 
 CATEGORICAL_LABEL_TO_VOCAB = {
-                    "cpu_architecture": ["Sandy Bridge", "Ivy Bridge", "Haswell", "Broadwell", "Sky Lake", "Cascade Lake", "Coffee Lake", "Alder Lake"],
-                    "node_info": ["1"],
-                    "cpu_scaling_frequency_hertz": ["1GHz", "2GHz", "3GHz"],
-                    }
+    "cpu_architecture": ["Sandy Bridge", "Ivy Bridge", "Haswell", "Broadwell", "Sky Lake", "Cascade Lake", "Coffee Lake", "Alder Lake"],
+    "node_info": ["1"],
+    "cpu_scaling_frequency_hertz": ["1GHz", "2GHz", "3GHz"],
+}
 
-no_weight_trainers = ["PolynomialRegressionTrainer", "GradientBoostingRegressorTrainer", "KNeighborsRegressorTrainer", "LinearRegressionTrainer", "SVRRegressorTrainer", "XgboostFitTrainer"]
+no_weight_trainers = [
+    "PolynomialRegressionTrainer",
+    "GradientBoostingRegressorTrainer",
+    "KNeighborsRegressorTrainer",
+    "LinearRegressionTrainer",
+    "SVRRegressorTrainer",
+    "XgboostFitTrainer",
+]
 weight_support_trainers = ["SGDRegressorTrainer", "LogarithmicRegressionTrainer", "LogisticRegressionTrainer", "ExponentialRegressionTrainer"]
 default_trainer_names = no_weight_trainers + weight_support_trainers
 default_trainers = ",".join(default_trainer_names)
@@ -70,12 +77,14 @@ class ModelOutputType(enum.Enum):
     AbsPower = 1
     DynPower = 2
 
+
 class NodeAttribute(str, enum.Enum):
     PROCESSOR = "processor"
     CORES = "cores"
     CHIPS = "chips"
     MEMORY = "memory"
     FREQ = "frequency"
+
 
 def is_output_type_supported(output_type_name):
     return any(output_type_name == item.name for item in ModelOutputType)
@@ -122,8 +131,9 @@ default_dram_feature_map = {
     FeatureGroup.BPFOnly: "bpf_page_cache_hit",
     FeatureGroup.BPFIRQ: "bpf_page_cache_hit",
     FeatureGroup.CounterIRQCombined: "cache_miss",
-    FeatureGroup.Basic: "cache_miss"
+    FeatureGroup.Basic: "cache_miss",
 }
+
 
 def main_feature(feature_group_name, energy_component):
     feature_group = FeatureGroup[feature_group_name]
@@ -164,7 +174,14 @@ class XGBoostModelFeatureOrLabelIncompatabilityException(Exception):
     features_incompatible: bool
     labels_incompatible: bool
 
-    def __init__(self, expected_features: list[str], expected_labels: list[str], received_features: list[str], received_labels: list[str], message="expected features/labels are the not the same as the features/labels of the training data") -> None:
+    def __init__(
+        self,
+        expected_features: list[str],
+        expected_labels: list[str],
+        received_features: list[str],
+        received_labels: list[str],
+        message="expected features/labels are the not the same as the features/labels of the training data",
+    ) -> None:
         self.expected_features = expected_features
         self.expected_labels = expected_labels
         self.received_features = received_features
@@ -240,11 +257,13 @@ def is_weight_output(output_type):
         return True
     return False
 
+
 def convert_enery_source(energy_source: str) -> str:
     # TODO: need revisit if get more than one rapl energy source
     if energy_source is None or "rapl" in energy_source:
         return "rapl-sysfs"
     return energy_source
+
 
 if __name__ == "__main__":
     for g, g_features in FeatureGroups.items():

--- a/tests/client_load_tester.py
+++ b/tests/client_load_tester.py
@@ -7,7 +7,7 @@ from estimator_power_request_test import Client
 loads = range(10, 11, 10)
 duration = 120
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     client = Client(SERVE_SOCKET)
     for model_name in model_names:
         for load in loads:
@@ -15,6 +15,6 @@ if __name__ == '__main__':
             start_time = time.time()
             client.make_request(request_json)
             elapsed_time = time.time() - start_time
-            output = f'{model_name},{load},{elapsed_time}'
+            output = f"{model_name},{load},{elapsed_time}"
             print(output)
             time.sleep(1)

--- a/tests/common_plot.py
+++ b/tests/common_plot.py
@@ -34,7 +34,16 @@ def preprocess_data(df):
 from extractor_test import get_expected_power_columns, get_extract_results, test_energy_source, test_extractors
 
 
-def plot_extract_result(extractor_name, feature_group, result, energy_source=test_energy_source, label_cols=get_expected_power_columns(), save_path=plot_output_path, features=None, title=None):
+def plot_extract_result(
+    extractor_name,
+    feature_group,
+    result,
+    energy_source=test_energy_source,
+    label_cols=get_expected_power_columns(),
+    save_path=plot_output_path,
+    features=None,
+    title=None,
+):
     energy_components = PowerSourceMap[energy_source]
     extracted_power_labels = get_extracted_power_labels(result, energy_components, label_cols)
     extracted_power_labels = preprocess_data(extracted_power_labels[5:])
@@ -42,7 +51,7 @@ def plot_extract_result(extractor_name, feature_group, result, energy_source=tes
     if features is None:
         features = FeatureGroups[FeatureGroup[feature_group]]
     ncols = max(len(features), len(energy_components))
-    fig, axes = plt.subplots(nrows=2, ncols=ncols, figsize=(5+2*len(features),5))
+    fig, axes = plt.subplots(nrows=2, ncols=ncols, figsize=(5 + 2 * len(features), 5))
     axes = np.array(axes).ravel()
     i = 0
     for feature in features:
@@ -60,7 +69,7 @@ def plot_extract_result(extractor_name, feature_group, result, energy_source=tes
         axes[i].set_title(f"{component_label_col}")
         axes[i].set_ylabel("")
         i += 1
-    while i < 2*ncols:
+    while i < 2 * ncols:
         fig.delaxes(axes[i])
         i += 1
     if title is None:

--- a/tests/estimator_model_request_test.py
+++ b/tests/estimator_model_request_test.py
@@ -98,7 +98,13 @@ def test_model_request():
     if os.path.exists(output_path):
         shutil.rmtree(output_path)
     # valid model
-    os.environ[init_url_key] = get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.BPFOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)
+    os.environ[init_url_key] = get_url(
+        energy_source=energy_source,
+        output_type=output_type,
+        feature_group=FeatureGroup.BPFOnly,
+        model_topurl=model_topurl,
+        pipeline_name=default_train_output_pipeline,
+    )
     print("Requesting from ", os.environ[init_url_key])
     request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.BPFOnly], output_type=output_type_name)
     data = json.dumps(request_json)
@@ -107,14 +113,22 @@ def test_model_request():
     print(f"result {output_type_name}/{FeatureGroup.BPFOnly.name} from static set: {output}")
     del loaded_model[output_type_name][energy_source]
     # invalid model
-    os.environ[init_url_key] = get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.BPFOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)
+    os.environ[init_url_key] = get_url(
+        energy_source=energy_source,
+        output_type=output_type,
+        feature_group=FeatureGroup.BPFOnly,
+        model_topurl=model_topurl,
+        pipeline_name=default_train_output_pipeline,
+    )
     print("Requesting from ", os.environ[init_url_key])
     request_json = generate_request(None, n=10, metrics=FeatureGroups[FeatureGroup.CounterOnly], output_type=output_type_name)
     data = json.dumps(request_json)
     power_request = json.loads(data, object_hook=lambda d: PowerRequest(**d))
     output_path = get_achived_model(power_request)
     assert output_path is None, f"model should be invalid\n {output_path}"
-    os.environ["MODEL_CONFIG"] = f"{estimator_enable_key}=true\n{init_url_key}={get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.BPFOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)}\n"
+    os.environ["MODEL_CONFIG"] = (
+        f"{estimator_enable_key}=true\n{init_url_key}={get_url(energy_source=energy_source, output_type=output_type, feature_group=FeatureGroup.BPFOnly, model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)}\n"
+    )
     set_env_from_model_config()
     print("Requesting from ", os.environ[init_url_key])
     reset_failed_list()

--- a/tests/estimator_model_test.py
+++ b/tests/estimator_model_test.py
@@ -32,7 +32,9 @@ def test_model(group_path, model_name, test_data_with_label, power_columns, powe
     for energy_component, _ in predicted_power_map.items():
         label_power_columns = [col for col in power_columns if energy_component in col]
         predicted_power_colname = default_predicted_col_func(energy_component)
-        sum_power_label = test_data_with_label.groupby([TIMESTAMP_COL])[label_power_columns].mean().sum(axis=1).sort_index()[label_power_columns].sum(axis=1).sort_index()
+        sum_power_label = (
+            test_data_with_label.groupby([TIMESTAMP_COL])[label_power_columns].mean().sum(axis=1).sort_index()[label_power_columns].sum(axis=1).sort_index()
+        )
         sum_predicted_power = data_with_prediction.groupby([TIMESTAMP_COL]).sum().sort_index()[predicted_power_colname]
         mae, mse, mape = compute_error(sum_power_label, sum_predicted_power)
         if power_range is None:

--- a/tests/estimator_power_request_test.py
+++ b/tests/estimator_power_request_test.py
@@ -14,7 +14,9 @@ trainer_names = ["SGDRegressorTrainer"]
 test_energy_sources = ["acpi", "rapl-sysfs"]
 
 
-def generate_request(train_name, n=1, metrics=WORKLOAD_FEATURES, system_features=SYSTEM_FEATURES, output_type=ModelOutputType.DynPower.name, energy_source=test_energy_source):
+def generate_request(
+    train_name, n=1, metrics=WORKLOAD_FEATURES, system_features=SYSTEM_FEATURES, output_type=ModelOutputType.DynPower.name, energy_source=test_energy_source
+):
     request_json = dict()
     if train_name is not None:
         request_json["trainer_name"] = train_name

--- a/tests/extractor_test.py
+++ b/tests/extractor_test.py
@@ -82,10 +82,19 @@ def assert_extract(extracted_data, power_columns, energy_components, num_of_unit
     assert len(power_columns) == expected_power_column_length, f"unexpected power label columns {power_columns}, expected {expected_power_column_length}"
     # TODO: if ratio applied, expected_col_size must + 1 for power_ratio
     expected_col_size = expected_power_column_length + len(FeatureGroups[FeatureGroup[feature_group]]) + num_of_unit  # power ratio
-    assert len(extracted_data_column_names) == expected_col_size, f"unexpected column length: expected {expected_col_size}, got {extracted_data_column_names}({len(extracted_data_column_names)}) "
+    assert (
+        len(extracted_data_column_names) == expected_col_size
+    ), f"unexpected column length: expected {expected_col_size}, got {extracted_data_column_names}({len(extracted_data_column_names)}) "
 
 
-def process(query_results, feature_group, save_path=extractor_output_path, customize_extractors=test_customize_extractors, energy_source=test_energy_source, num_of_unit=2):
+def process(
+    query_results,
+    feature_group,
+    save_path=extractor_output_path,
+    customize_extractors=test_customize_extractors,
+    energy_source=test_energy_source,
+    num_of_unit=2,
+):
     energy_components = PowerSourceMap[energy_source]
     global test_extractors
     for extractor_name in customize_extractors:

--- a/tests/isolator_test.py
+++ b/tests/isolator_test.py
@@ -33,12 +33,15 @@ profile_map = DefaultProfiler.process(test_idle_data)
 test_profiles = generate_profiles(profile_map)
 test_isolators = [MinIdleIsolator(), NoneIsolator()]
 
+
 def get_filename(isolator_name, extractor_name, feature_group):
     return f"{isolator_name}_{extractor_name}_{feature_group}_{False}"
+
 
 def get_isolate_result(isolator_name, extractor_name, feature_group, save_path=isolator_output_path):
     filename = get_filename(isolator_name, extractor_name, feature_group)
     return load_csv(save_path, filename)
+
 
 def get_isolate_results(isolator_name, extractor_name, save_path=isolator_output_path):
     all_results = dict()
@@ -48,22 +51,28 @@ def get_isolate_results(isolator_name, extractor_name, save_path=isolator_output
             all_results[feature_group] = result
     return all_results
 
+
 def save_results(instance, extractor_name, feature_group, isolated_data, save_path=isolator_output_path):
     filename = get_filename(instance.__class__.__name__, extractor_name, feature_group)
     save_csv(save_path, filename, isolated_data)
+
 
 def assert_isolate(extractor_result, isolated_data):
     isolated_data_column_names = isolated_data.columns
     assert isolated_data is not None, "isolated data is None"
     value_df = isolated_data.reset_index().drop(columns=container_level_index)
-    negative_df = value_df[(value_df<0).all(1)]
+    negative_df = value_df[(value_df < 0).all(1)]
     assert len(negative_df) == 0, f"all data must be non-negative \n {negative_df}"
-    assert len(extractor_result.columns) == len(isolated_data_column_names), f"unexpected column length: expected {len(extractor_result.columns)}, got {isolated_data_column_names}({len(isolated_data_column_names)}) "
+    assert len(extractor_result.columns) == len(
+        isolated_data_column_names
+    ), f"unexpected column length: expected {len(extractor_result.columns)}, got {isolated_data_column_names}({len(isolated_data_column_names)}) "
+
 
 def find_correlation_of_isolated_data(isolated_data, workload_features, energy_source=test_energy_source, power_columns=get_expected_power_columns()):
     feature_power_data = isolated_data.groupby(node_level_index).sum()
     corr = find_correlations(energy_source, feature_power_data, power_columns, workload_features)
     return corr
+
 
 def get_max_corr(isolated_data, workload_features, energy_source=test_energy_source, power_columns=get_expected_power_columns()):
     corr_data = find_correlation_of_isolated_data(isolated_data, workload_features, energy_source=energy_source, power_columns=power_columns)
@@ -75,6 +84,7 @@ def get_max_corr(isolated_data, workload_features, energy_source=test_energy_sou
         print(e)
     return corr
 
+
 def process(test_isolators=test_isolators, customize_isolators=[], extract_path=extractor_output_path, save_path=isolator_output_path):
     for custom_isolator in customize_isolators:
         test_isolators += [custom_isolator]
@@ -85,12 +95,13 @@ def process(test_isolators=test_isolators, customize_isolators=[], extract_path=
             extractor_results = get_extract_results(extractor_name, node_level=False, save_path=extract_path)
             for feature_group, extract_result in extractor_results.items():
                 print(f"{isolator_name} isolate {extractor_name}_{feature_group}")
-                isolated_data = test_instance.isolate(extract_result,label_cols=get_expected_power_columns(), energy_source=test_energy_source)
+                isolated_data = test_instance.isolate(extract_result, label_cols=get_expected_power_columns(), energy_source=test_energy_source)
                 workload_features = FeatureGroups[FeatureGroup[feature_group]]
                 corr = find_correlation_of_isolated_data(isolated_data, workload_features)
                 print(corr)
                 assert_isolate(extract_result, isolated_data)
                 save_results(test_instance, extractor_name, feature_group, isolated_data, save_path=save_path)
+
 
 def test_isolators_process():
     # Add customize isolator here

--- a/tests/minimal_trainer.py
+++ b/tests/minimal_trainer.py
@@ -6,4 +6,9 @@ trainer_names = ["GradientBoostingRegressorTrainer", "SGDRegressorTrainer", "Xgb
 valid_feature_groups = [FeatureGroup.BPFOnly]
 
 if __name__ == "__main__":
-    process(target_energy_sources=["acpi", "rapl-sysfs"], abs_trainer_names=trainer_names, dyn_trainer_names=trainer_names, valid_feature_groups=valid_feature_groups)
+    process(
+        target_energy_sources=["acpi", "rapl-sysfs"],
+        abs_trainer_names=trainer_names,
+        dyn_trainer_names=trainer_names,
+        valid_feature_groups=valid_feature_groups,
+    )

--- a/tests/model_select_test.py
+++ b/tests/model_select_test.py
@@ -16,33 +16,36 @@ from kepler_model.util.similarity import compute_jaccard_similarity
 from kepler_model.util.train_types import FeatureGroup, FeatureGroups, ModelOutputType, NodeAttribute
 from tests.model_server_test import get_model_request_json
 
-TMP_FILE = 'download.zip'
+TMP_FILE = "download.zip"
 test_data_path = os.path.join(os.path.dirname(__file__), "data")
 
 # set environment
-os.environ['MODEL_SERVER_URL'] = 'http://localhost:8100'
+os.environ["MODEL_SERVER_URL"] = "http://localhost:8100"
 test_energy_sources = ["rapl-sysfs"]
+
 
 def get_node_types(energy_source):
     pipeline_name = default_pipelines[energy_source]
     url_path = os.path.join(base_model_url, pipeline_name, NODE_TYPE_INDEX_FILENAME)
     return load_remote_json(url_path)
 
-def make_request_with_spec(metrics, output_type, node_type=-1, trainer_name="", energy_source='rapl-sysfs', spec=None):
+
+def make_request_with_spec(metrics, output_type, node_type=-1, trainer_name="", energy_source="rapl-sysfs", spec=None):
     weight = False
     model_request = get_model_request_json(metrics, output_type, node_type, weight, trainer_name, energy_source)
     model_request["machine_spec"] = spec
-    response = requests.post(f'http://localhost:{MODEL_SERVER_PORT}/model', json=model_request)
+    response = requests.post(f"http://localhost:{MODEL_SERVER_PORT}/model", json=model_request)
     assert response.status_code == 200, response.text
     output_path = os.path.join(download_path, output_type.name)
     if os.path.exists(output_path):
         shutil.rmtree(output_path)
-    with codecs.open(TMP_FILE, 'wb') as f:
+    with codecs.open(TMP_FILE, "wb") as f:
         f.write(response.content)
     shutil.unpack_archive(TMP_FILE, output_path)
     metadata = load_metadata(output_path)
     os.remove(TMP_FILE)
     return metadata["model_name"], metadata["features"]
+
 
 def check_select_model(model_name, features, best_model_map):
     assert model_name != "", "model name should not be empty."
@@ -51,9 +54,12 @@ def check_select_model(model_name, features, best_model_map):
         cmp_metrics = FeatureGroups[FeatureGroup[cmp_fg_name]]
         if cmp_metrics == features:
             found = True
-            assert model_name == expected_best_model_without_node_type, f"should select best model {expected_best_model_without_node_type} (select {model_name})"
+            assert (
+                model_name == expected_best_model_without_node_type
+            ), f"should select best model {expected_best_model_without_node_type} (select {model_name})"
             break
     assert found, f"must found matched best model without node_type for {features}: {best_model_map}"
+
 
 def process(node_type, info, output_type, energy_source, valid_fgs, best_model_by_source):
     expected_suffix = f"_{node_type}"
@@ -64,22 +70,23 @@ def process(node_type, info, output_type, energy_source, valid_fgs, best_model_b
         model_name, features = make_request_with_spec(metrics, output_type, node_type=node_type, energy_source=energy_source)
         assert expected_suffix in model_name, "model must be a matched type"
         check_select_model(model_name, features, valid_fgs)
-        model_name, features = make_request_with_spec(metrics, output_type, spec=info['attrs'], energy_source=energy_source)
+        model_name, features = make_request_with_spec(metrics, output_type, spec=info["attrs"], energy_source=energy_source)
         assert expected_suffix in model_name, "model must be a matched type"
         check_select_model(model_name, features, valid_fgs)
-        fixed_some_spec = {'processor': info['attrs']['processor'], 'memory': info['attrs']['memory']}
+        fixed_some_spec = {"processor": info["attrs"]["processor"], "memory": info["attrs"]["memory"]}
         model_name, features = make_request_with_spec(metrics, output_type, spec=fixed_some_spec, energy_source=energy_source)
         assert expected_suffix in model_name, "model must be a matched type"
         check_select_model(model_name, features, valid_fgs)
-        uncovered_spec = info['attrs'].copy()
-        uncovered_spec['processor'] = "_".join(uncovered_spec['processor'].split("_")[:-1])
+        uncovered_spec = info["attrs"].copy()
+        uncovered_spec["processor"] = "_".join(uncovered_spec["processor"].split("_")[:-1])
         model_name, features = make_request_with_spec(metrics, output_type, spec=uncovered_spec, energy_source=energy_source)
         assert expected_suffix in model_name, "model must be a matched type"
         check_select_model(model_name, features, valid_fgs)
 
+
 def test_process():
     # test getting model from server
-    os.environ['MODEL_SERVER_ENABLE'] = "true"
+    os.environ["MODEL_SERVER_ENABLE"] = "true"
     available_models = list_all_models()
     assert len(available_models) > 0, "must have more than one available models"
     print("Available Models:", available_models)
@@ -94,6 +101,7 @@ def test_process():
                     process(node_type, info, output_type, energy_source, valid_fgs, best_model_by_source=best_model_by_source_map[output_type_name])
             else:
                 print(f"skip {energy_source}/{node_type} because on available models")
+
 
 def test_get_node_type():
     node_collection = NodeTypeIndexCollection(test_data_path)
@@ -114,19 +122,21 @@ def test_get_node_type():
     assert cmp_index != -1
     assert looseness > 0
 
+
 def test_similarity_computation():
     for energy_source in test_energy_sources:
         node_types = get_node_types(energy_source)
         for node_type, info in node_types.items():
-            spec = NodeTypeSpec(**info['attrs'])
+            spec = NodeTypeSpec(**info["attrs"])
             for cmp_node_type, cmp_info in node_types.items():
-                cmp_spec = NodeTypeSpec(**cmp_info['attrs'])
+                cmp_spec = NodeTypeSpec(**cmp_info["attrs"])
                 similarity = spec.get_similarity(cmp_spec, debug=True)
                 if node_type == cmp_node_type:
                     assert similarity == 1, "similarity must be one for the same type"
                 else:
                     assert similarity >= 0, f"similarity must be >= 0, {node_type}-{cmp_node_type} ({similarity})"
                     assert similarity <= 1, f"similarity must be <= 1, {node_type}-{cmp_node_type} ({similarity})"
+
 
 def test_compute_jaccard_similarity():
     testcases = {
@@ -138,7 +148,8 @@ def test_compute_jaccard_similarity():
     for tc, value in testcases.items():
         assert compute_jaccard_similarity(tc[0], tc[1]) == value
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_process()
     test_similarity_computation()
     test_compute_jaccard_similarity()

--- a/tests/model_server_test.py
+++ b/tests/model_server_test.py
@@ -16,7 +16,14 @@ TMP_FILE = "tmp.zip"
 
 
 def get_model_request_json(metrics, output_type, node_type, weight, trainer_name, energy_source):
-    return {"metrics": metrics, "output_type": output_type.name, "node_type": node_type, "weight": weight, "trainer_name": trainer_name, "source": energy_source}
+    return {
+        "metrics": metrics,
+        "output_type": output_type.name,
+        "node_type": node_type,
+        "weight": weight,
+        "trainer_name": trainer_name,
+        "source": energy_source,
+    }
 
 
 def make_request(metrics, output_type, node_type=any_node_type, weight=False, trainer_name="", energy_source="rapl-sysfs"):
@@ -57,29 +64,18 @@ def get_models():
     response = json.loads(response.text)
     return response
 
+
 def test_attr_has_value():
     attrs = dict()
-    non_numerical_test_cases = {
-        "": False,
-        None: False,
-        "some": True
-    }
-    numerical_test_cases = {
-        "": False,
-        None: False,
-        "0": False,
-        0: False,
-        "-1": False,
-        -1: False,
-        "1": True,
-        1: True
-    }
+    non_numerical_test_cases = {"": False, None: False, "some": True}
+    numerical_test_cases = {"": False, None: False, "0": False, 0: False, "-1": False, -1: False, "1": True, 1: True}
     for tc, value in non_numerical_test_cases.items():
         attrs[NodeAttribute.PROCESSOR] = tc
         assert attr_has_value(attrs, NodeAttribute.PROCESSOR) == value
     for tc, value in numerical_test_cases.items():
         attrs[NodeAttribute.CORES] = tc
         assert attr_has_value(attrs, NodeAttribute.CORES) == value
+
 
 def test_model_request():
     models = get_models()
@@ -112,6 +108,7 @@ def test_model_request():
     make_request(metrics, output_type, trainer_name=trainer_name, node_type=1, weight=True)
     # with acpi source
     make_request(metrics, output_type, energy_source="acpi", trainer_name=trainer_name, node_type=1, weight=True)
+
 
 if __name__ == "__main__":
     test_attr_has_value()

--- a/tests/model_tester.py
+++ b/tests/model_tester.py
@@ -81,7 +81,16 @@ def process(train_dataset_name, test_dataset_name, target_path):
 
                         # for each energy_component
                         for energy_component, values in predicted_data.items():
-                            item = {"train_dataset": train_dataset_name, "test_dataset": test_dataset_name, "isolator": isolator, "energy_source": energy_source, "feature_group": feature_group, "model": model.name, "model_path": model_path, "energy_component": energy_component}
+                            item = {
+                                "train_dataset": train_dataset_name,
+                                "test_dataset": test_dataset_name,
+                                "isolator": isolator,
+                                "energy_source": energy_source,
+                                "feature_group": feature_group,
+                                "model": model.name,
+                                "model_path": model_path,
+                                "energy_component": energy_component,
+                            }
 
                             label_power_columns = [col for col in power_columns if energy_component in col]
                             # sum label value for all unit
@@ -132,4 +141,3 @@ if __name__ == "__main__":
     target_path = offline_trainer_output_path
     # same train/test dataset
     process(dataset_name, dataset_name, target_path)
-

--- a/tests/offline_trainer_test.py
+++ b/tests/offline_trainer_test.py
@@ -82,7 +82,9 @@ def assert_offline_trainer_output(target_path, energy_source, valid_fgs, pipelin
     _assert_offline_trainer(dyn_models)
 
 
-def process(dataset_name, train_prom_response, idle_prom_response, energy_source=test_energy_source, isolators=isolators, target_path=offline_trainer_output_path):
+def process(
+    dataset_name, train_prom_response, idle_prom_response, energy_source=test_energy_source, isolators=isolators, target_path=offline_trainer_output_path
+):
     idle_data = prom_responses_to_results(idle_prom_response)
     valid_fgs = get_valid_feature_group_from_queries(idle_data)
 

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -14,7 +14,9 @@ test_energy_sources = ["acpi", "rapl-sysfs"]
 
 
 def assert_pipeline(pipeline, query_results, feature_group, energy_source, energy_components):
-    success, abs_data, dyn_data = pipeline.process(query_results, energy_components, energy_source, feature_group=feature_group.name, replace_node_type=default_node_type)
+    success, abs_data, dyn_data = pipeline.process(
+        query_results, energy_components, energy_source, feature_group=feature_group.name, replace_node_type=default_node_type
+    )
     assert success, f"failed to process pipeline {pipeline.name}"
     for trainer in pipeline.trainers:
         if trainer.feature_group == feature_group and trainer.energy_source == energy_source:
@@ -40,7 +42,15 @@ def process(
         valid_feature_groups = get_valid_feature_group_from_queries(query_results.keys())
     for extractor in extractors:
         for isolator in isolators:
-            pipeline = NewPipeline(save_pipeline_name, abs_trainer_names, dyn_trainer_names, extractor=extractor, isolator=isolator, target_energy_sources=target_energy_sources, valid_feature_groups=valid_feature_groups)
+            pipeline = NewPipeline(
+                save_pipeline_name,
+                abs_trainer_names,
+                dyn_trainer_names,
+                extractor=extractor,
+                isolator=isolator,
+                target_energy_sources=target_energy_sources,
+                valid_feature_groups=valid_feature_groups,
+            )
             global spec
             pipeline.node_collection.index_train_machine("test", spec)
             for energy_source in target_energy_sources:

--- a/tests/query_test.py
+++ b/tests/query_test.py
@@ -23,4 +23,3 @@ if __name__ == "__main__":
             data = prom_client.get_data(query_metric, features)
             print(f"Query: {query_metric} Type: {fg.name} Features: {features}")
             print(None if data is None else data.head())
-

--- a/tests/trainer_test.py
+++ b/tests/trainer_test.py
@@ -35,7 +35,15 @@ def assert_train(trainer, data, energy_components):
                 pass
 
 
-def process(node_level, feature_group, result, trainer_names=test_trainer_names, energy_source=test_energy_source, power_columns=get_expected_power_columns(), pipeline_name=default_train_output_pipeline):
+def process(
+    node_level,
+    feature_group,
+    result,
+    trainer_names=test_trainer_names,
+    energy_source=test_energy_source,
+    power_columns=get_expected_power_columns(),
+    pipeline_name=default_train_output_pipeline,
+):
     energy_components = PowerSourceMap[energy_source]
     train_items = []
     for trainer_name in trainer_names:
@@ -47,7 +55,14 @@ def process(node_level, feature_group, result, trainer_names=test_trainer_names,
     return pd.concat(train_items)
 
 
-def process_all(extractors=test_extractors, isolators=test_isolators, trainer_names=test_trainer_names, energy_source=test_energy_source, power_columns=get_expected_power_columns(), pipeline_name=default_train_output_pipeline):
+def process_all(
+    extractors=test_extractors,
+    isolators=test_isolators,
+    trainer_names=test_trainer_names,
+    energy_source=test_energy_source,
+    power_columns=get_expected_power_columns(),
+    pipeline_name=default_train_output_pipeline,
+):
     abs_train_list = []
     dyn_train_list = []
     for extractor in extractors:
@@ -55,7 +70,9 @@ def process_all(extractors=test_extractors, isolators=test_isolators, trainer_na
         extractor_results = get_extract_results(extractor_name, node_level=True)
         for feature_group, result in extractor_results.items():
             print("Extractor ", extractor_name)
-            metadata_df = process(True, feature_group, result, trainer_names=trainer_names, energy_source=energy_source, power_columns=power_columns, pipeline_name=pipeline_name)
+            metadata_df = process(
+                True, feature_group, result, trainer_names=trainer_names, energy_source=energy_source, power_columns=power_columns, pipeline_name=pipeline_name
+            )
             metadata_df["extractor"] = extractor_name
             metadata_df["feature_group"] = feature_group
             abs_train_list += [metadata_df]
@@ -65,7 +82,15 @@ def process_all(extractors=test_extractors, isolators=test_isolators, trainer_na
             isolator_results = get_isolate_results(isolator_name, extractor_name)
             for feature_group, result in isolator_results.items():
                 print("Isolator ", isolator_name)
-                metadata_df = process(False, feature_group, result, trainer_names=trainer_names, energy_source=energy_source, power_columns=power_columns, pipeline_name=pipeline_name)
+                metadata_df = process(
+                    False,
+                    feature_group,
+                    result,
+                    trainer_names=trainer_names,
+                    energy_source=energy_source,
+                    power_columns=power_columns,
+                    pipeline_name=pipeline_name,
+                )
                 metadata_df["extractor"] = extractor_name
                 metadata_df["isolator"] = isolator_name
                 metadata_df["feature_group"] = feature_group

--- a/tests/xgboost_test.py
+++ b/tests/xgboost_test.py
@@ -25,9 +25,13 @@ if __name__ == "__main__":
     assert len(query_results) > 0, "cannot read_sample_query_results"
     instance = DefaultExtractor()
     extracted_data, power_columns, _, _ = instance.extract(query_results, energy_components, feature_group, energy_source, node_level=True)
-    xgb_container_level_pipeline_kfold = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "test_models/XGBoost/", node_level=True)
+    xgb_container_level_pipeline_kfold = XGBoostRegressionStandalonePipeline(
+        XGBoostRegressionTrainType.KFoldCrossValidation, "test_models/XGBoost/", node_level=True
+    )
     xgb_node_pipeline_kfold = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.KFoldCrossValidation, "test_models/XGBoost/", node_level=False)
-    xgb_container_level_pipeline_tts = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.TrainTestSplitFit, "test_models/XGBoost/", node_level=False)
+    xgb_container_level_pipeline_tts = XGBoostRegressionStandalonePipeline(
+        XGBoostRegressionTrainType.TrainTestSplitFit, "test_models/XGBoost/", node_level=False
+    )
     xgb_node_pipeline_tts = XGBoostRegressionStandalonePipeline(XGBoostRegressionTrainType.TrainTestSplitFit, "test_models/XGBoost/", node_level=True)
     xgb_node_pipeline_kfold.train(None, query_results)
     xgb_container_level_pipeline_tts.train(None, query_results)


### PR DESCRIPTION
This commit adds provision to run `hatch fmt` on the code base. The changes include:

- Set the line length to 160 in the pyproject.toml
- Formatting the entire codebase using `hatch fmt`
- Adding a new Makefile target `make fmt`, which allows developers to run `hatch fmt` locally as well as on CI.
- Modifying the CI workflow to automatically execute `make fmt` on the code

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [ ] Run the following command to format your code:

  ```bash
  hatch fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
