### PR TITLE
fix(xgboost): Remove xgboost dependency to reduce image sizes

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -35,7 +35,6 @@ env:
 
 jobs:
   run-integration:
-    if: ${{ (inputs.base_change != 'true') || ( (inputs.base_change == 'true') && (inputs.docker_secret == 'true') ) }}
     runs-on: ubuntu-20.04
     steps:
       - name: use Kepler action to deploy cluster

--- a/.github/workflows/tekton-test.yml
+++ b/.github/workflows/tekton-test.yml
@@ -42,7 +42,6 @@ env:
 
 jobs:
   tekton-test:
-    if: ${{ (inputs.base_change != 'true') || ( (inputs.base_change == 'true') && (inputs.docker_secret == 'true') ) }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "scipy==1.14.1",
   "seaborn==0.13.2",
   "Werkzeug==3.0.4",
-  "xgboost==2.1.1",
   "boto3==1.34.155",
   "pymarkdownlnt==0.9.22",
   "yamllint==1.35.1",

--- a/src/kepler_model/estimate/model/model.py
+++ b/src/kepler_model/estimate/model/model.py
@@ -1,11 +1,15 @@
 import json
 import logging
+import importlib.util as import_util
 
 import pandas as pd
 
 from kepler_model.estimate.model.curvefit_model import CurveFitModelEstimator
 from kepler_model.estimate.model.scikit_model import ScikitModelEstimator
-from kepler_model.estimate.model.xgboost_model import XgboostModelEstimator
+
+if import_util.find_spec("xgboost"):
+    from kepler_model.estimate.model.xgboost_model import XgboostModelEstimator
+
 from kepler_model.util.config import download_path
 from kepler_model.util.loader import get_download_output_path, load_metadata
 from kepler_model.util.prom_types import valid_container_query
@@ -17,10 +21,12 @@ logger = logging.getLogger(__name__)
 # model wrapper
 MODELCLASS = {
     "scikit": ScikitModelEstimator,
-    "xgboost": XgboostModelEstimator,
     "curvefit": CurveFitModelEstimator,
     # 'keras': KerasModelEstimator,
 }
+
+if import_util.find_spec("xgboost"):
+    MODELCLASS["xgboost"] = XgboostModelEstimator
 
 
 def default_predicted_col_func(energy_component):

--- a/src/kepler_model/util/train_types.py
+++ b/src/kepler_model/util/train_types.py
@@ -10,6 +10,7 @@
 
 import enum
 import random
+import importlib.util as import_util
 
 SYSTEM_FEATURES = ["node_info", "cpu_scaling_frequency_hertz"]
 
@@ -45,8 +46,11 @@ no_weight_trainers = [
     "KNeighborsRegressorTrainer",
     "LinearRegressionTrainer",
     "SVRRegressorTrainer",
-    "XgboostFitTrainer",
 ]
+
+if import_util.find_spec("xgboost"):
+    no_weight_trainers.append("XgboostFitTrainer")
+
 weight_support_trainers = ["SGDRegressorTrainer", "LogarithmicRegressionTrainer", "LogisticRegressionTrainer", "ExponentialRegressionTrainer"]
 default_trainer_names = no_weight_trainers + weight_support_trainers
 default_trainers = ",".join(default_trainer_names)


### PR DESCRIPTION
  `xgboost` and its dependency `nvidia` each contribute to half the size of the model-server base image.

  This commit:
  - removes `xgboost`, and its dependency nvidia from the project
  - changes to model training code which uses `xgboost` to detect if `xgboost` is not present and skips execution

Image size comparison:

  - Image sizes before change
  ```
  quay.io/sustainable_computing_io/kepler_model_server        v0.7.11-2        dce5c5495a67   18 minutes ago   1.21GB
  quay.io/sustainable_computing_io/kepler_model_server_base   v0.7.11-2        c59e2a1a5f43   27 minutes ago   1.19GB
  ```

  - Image sizes after change
  ```
  quay.io/sustainable_computing_io/kepler_model_server        v0.7.11-2        1521f5b2612d   2 hours ago      688MB
  quay.io/sustainable_computing_io/kepler_model_server_base   v0.7.11-2        5ae7b07a679b   2 hours ago      686MB
  ```

 Any time if we need to use xgboost, just add xgboost to `pyproject.toml`, and re-run the test and pipeline.

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [x] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
