### PR TITLE
feat(vm_metrics): Use process metrics when using vm metrics to train

### DIFF
--- a/src/kepler_model/train/extractor/extractor.py
+++ b/src/kepler_model/train/extractor/extractor.py
@@ -174,8 +174,8 @@ class DefaultExtractor(Extractor):
                     aggr_query_data = aggr_query_data.loc[aggr_query_data["job"] == VM_JOB_NAME]
                 else:
                     aggr_query_data = aggr_query_data.loc[aggr_query_data["job"] != VM_JOB_NAME]
-                #print("aggr query data feature")
-                #print(aggr_query_data.to_string())
+                print("aggr query data feature")
+                print(aggr_query_data.to_string())
                 aggr_query_data.rename(columns={query: feature}, inplace=True)
                 aggr_query_data[container_id_colname] = aggr_query_data[cols_to_use].apply(lambda x: "/".join([str(xi) for xi in x]), axis=1)
                 # separate for each container_id

--- a/src/kepler_model/util/prom_types.py
+++ b/src/kepler_model/util/prom_types.py
@@ -40,6 +40,8 @@ MODE_COL = "mode"
 
 container_query_prefix = "kepler_container"
 container_query_suffix = "total"
+process_query_prefix = "kepler_process"
+process_query_suffix = "total"
 
 node_query_prefix = "kepler_node"
 node_query_suffix = "joules_total"
@@ -53,6 +55,7 @@ node_info_query = "kepler_node_node_info"
 cpu_frequency_info_query = "kepler_node_cpu_scaling_frequency_hertz"
 
 container_id_cols = ["container_id", "pod_name", "container_name", "container_namespace"]
+process_id_cols = ["container_id", "pid"]
 node_info_column = "node_type"
 pkg_id_column = "pkg_id"
 
@@ -63,13 +66,15 @@ def get_energy_unit(component):
     return None
 
 
-def feature_to_query(feature):
+def feature_to_query(feature, use_process=False):
     if feature in SYSTEM_FEATURES:
         return f"{node_query_prefix}_{feature}"
     if feature in FeatureGroups[FeatureGroup.AcceleratorOnly]:
         return f"{node_query_prefix}_{feature}"
     if FeatureGroup.ThirdParty in FeatureGroups is not None and feature in FeatureGroups[FeatureGroup.ThirdParty]:
         return feature
+    if use_process:
+        return f"{process_query_prefix}_{feature}_{process_query_suffix}"
     return f"{container_query_prefix}_{feature}_{container_query_suffix}"
 
 


### PR DESCRIPTION
This PR will enable process metrics to be used when training with vm metrics. Specifically, when vm metrics are enabled for training, models will be trained with features kepler_process from job="vm" and labels kepler_vm from baremetal.