### PR TITLE
chore: refactor and enhance e2e test script

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -35,7 +35,6 @@ env:
 
 jobs:
   run-integration:
-    if: ${{ (inputs.base_change != 'true') || ( (inputs.base_change == 'true') && (inputs.docker_secret == 'true') ) }}
     runs-on: ubuntu-20.04
     steps:
       - name: use Kepler action to deploy cluster
@@ -74,24 +73,31 @@ jobs:
       - name: test deploying with only estimator
         run: |
           make deploy
-          make e2e-test
+          ./tests/e2e_test.sh --estimator ${{ inputs.additional_opts }}
           make cleanup
         env:
-          OPTS: ESTIMATOR${{ inputs.additional_opts }}
+          OPTS: ESTIMATOR
           KEPLER_IMAGE_VERSION: ${{ inputs.kepler_tag }}
       - name: test deploying with only server
         run: |
           make deploy
-          make e2e-test
+          ./tests/e2e_test.sh --server ${{ inputs.additional_opts }}
           make cleanup
         env:
-          OPTS: SERVER${{ inputs.additional_opts }}
+          OPTS: SERVER
           KEPLER_IMAGE_VERSION: ${{ inputs.kepler_tag }}
       - name: test deploying with estimator and model server
         run: |
           make deploy
-          make e2e-test
+          ./tests/e2e_test.sh --estimator --server ${{ inputs.additional_opts }}
           make cleanup
         env:
-          OPTS: ESTIMATOR SERVER${{ inputs.additional_opts }}
+          OPTS: ESTIMATOR SERVER
           KEPLER_IMAGE_VERSION: ${{ inputs.kepler_tag }}
+
+      - name: upload artifacts on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: integration-test-artifacts
+          path: tmp/e2e

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -208,7 +208,7 @@ jobs:
       image_repo: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
       image_tag: ${{ needs.check-branch.outputs.tag }}
       kepler_tag: release-0.7.11
-      additional_opts: " TEST"
+      additional_opts: --test
 
   integration-test-with-exporter:
     needs: [check-secret, check-branch, check-change, base-image]
@@ -232,7 +232,7 @@ jobs:
       image_repo: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
       image_tag: ${{ needs.check-branch.outputs.tag }}
       kepler_tag: release-0.7.11
-      additional_opts: " DB"
+      additional_opts: --db
 
   integration-test-with-latest:
     needs: [check-secret, check-branch, check-change, base-image]
@@ -244,7 +244,7 @@ jobs:
       image_repo: ${{ vars.IMAGE_REPO || 'docker.io/library' }}
       image_tag: ${{ needs.check-branch.outputs.tag }}
       kepler_tag: latest
-      additional_opts: " DB"
+      additional_opts: --db
 
   verify_model_training_script:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,6 @@ manifest:
 	@./manifests/set.sh "${OPTS}"
 	@$(MAKE) _print
 
-e2e-test:
-	chmod +x ./tests/e2e_test.sh
-	./tests/e2e_test.sh test "${OPTS}"
-
 patch-power-request-client:
 	kubectl patch ds kepler-exporter -n kepler --patch-file ./manifests/test/power-request-client.yaml
 

--- a/hack/utils.bash
+++ b/hack/utils.bash
@@ -1,0 +1,86 @@
+#
+# Copyright 2024.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+is_fn() {
+  [[ $(type -t "$1") == "function" ]]
+  return $?
+}
+
+header() {
+  local title=" 🔆🔆🔆  $*  🔆🔆🔆 "
+
+  local len=40
+  if [[ ${#title} -gt $len ]]; then
+    len=${#title}
+  fi
+
+  echo -e "\n\n  \033[1m${title}\033[0m"
+  echo -n "━━━━━"
+  printf '━%.0s' $(seq "$len")
+  echo "━━━━━━━"
+
+}
+
+info() {
+  echo -e " 🔔 $*" >&2
+}
+
+err() {
+  echo -e " 😱 $*" >&2
+}
+
+warn() {
+  echo -e "   $*" >&2
+}
+
+ok() {
+  echo -e "   ✅ $*" >&2
+}
+
+skip() {
+  echo -e " 🙈 SKIP: $*" >&2
+}
+
+fail() {
+  echo -e " ❌ FAIL: $*" >&2
+}
+
+info_run() {
+  echo -e "      $*\n" >&2
+}
+
+run() {
+  echo -e " ❯ $*\n" >&2
+  "$@"
+}
+
+die() {
+  echo -e "\n ✋ $* "
+  echo -e "──────────────────── ⛔️⛔️⛔️ ────────────────────────\n"
+  exit 1
+}
+
+line() {
+  local len="$1"
+  local style="${2:-thin}"
+  shift
+
+  local ch='─'
+  [[ "$style" == 'heavy' ]] && ch="━"
+
+  printf "$ch%.0s" $(seq "$len") >&2
+  echo
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -320,20 +320,19 @@ hatch run test -vvv -s ./tests/model_select_test.py
 ## Integration Test
 
 ```bash
-./e2e_test.sh test "<deploy options>"  
-# e.g., ./e2e_test.sh test "ESTIMATOR TEST"
+./e2e_test.sh <options>
 ```
 
-| scenario                                    | test cases                                                            | deploy options        | status   |
-|---------------------------------------------|-----------------------------------------------------------------------|-----------------------|----------|
-| Kepler with estimator only                  | Latest Kepler image is connected to estimator                         | ESTIMATOR             | &#x2714; |
-|                                             | Estimator can load model from config                                  | ESTIMATOR             | &#x2714; |
-|                                             | Dummy power request can be made to estimator                          | ESTIMATOR TEST        | &#x2714; |
-| Kepler with model server only               | Latest Kepler image can request weight model from model server        | SERVER                | &#x2714; |
-|                                             | Dummy weight model request can be made to model server                | SERVER TEST           | &#x2714; |
-| Kepler with estimator and model server      | Estimator can load model from model server                            | ESTIMATOR SERVER      | &#x2714; |
-|                                             | Model server can load initial model                                   | ESTIMATOR SERVER      | &#x2714; |
-|                                             | Dummy power request can be made to estimator                          | ESTIMATOR SERVER TEST | &#x2714; |
-| Kepler with model server and online trainer | Kepler can provide metric to online trainer to train                  | ONLINE                | WIP      |
-|                                             | Dummy prometheus server can provide metric to online trainer to train | ONLINE TEST           | WIP      |
-|                                             | Trained model is updated to pipeline and availble on model server     |                       | WIP      |
+| scenario                                    | test cases                                                            | deploy options              | status   |
+|---------------------------------------------|-----------------------------------------------------------------------|-----------------------------|----------|
+| Kepler with estimator only                  | Latest Kepler image is connected to estimator                         | --estimator                 | &#x2714; |
+|                                             | Estimator can load model from config                                  | --estimator                 | &#x2714; |
+|                                             | Dummy power request can be made to estimator                          | --test --estimator          | &#x2714; |
+| Kepler with model server only               | Latest Kepler image can request weight model from model server        | --server                    | &#x2714; |
+|                                             | Dummy weight model request can be made to model server                | --test --server             | &#x2714; |
+| Kepler with estimator and model server      | Estimator can load model from model server                            | --estimator --server        | &#x2714; |
+|                                             | Model server can load initial model                                   | --estimator --server        | &#x2714; |
+|                                             | Dummy power request can be made to estimator                          | --test --estimator --server | &#x2714; |
+| Kepler with model server and online trainer | Kepler can provide metric to online trainer to train                  | ONLINE                      | WIP      |
+|                                             | Dummy prometheus server can provide metric to online trainer to train | ONLINE TEST                 | WIP      |
+|                                             | Trained model is updated to pipeline and availble on model server     |                             | WIP      |


### PR DESCRIPTION
This commit refactors the existing `e2e_test.sh` script, making it more
generic, modular.

Key updates include:
- Replaces the use of environment variables with command line arguments
  for better clarity and flexiability.
  ```
    💡 Examples:
      # Run test with estimator
        e2e_test.sh --estimator

      # Run test with model server
        e2e_test.sh --server

      # Run test with dummy weight model or power request
        e2e_test.sh --test

      # Enable model database
        e2e_test.sh --db

      # Run test with both estimator and server
        e2e_test.sh --estimator --server

      # Run test with estimator, server, and model database
        e2e_test.sh --estimator --server --db
  ```
- Test logs and other useful information are now stored in the `tmp/e2e` directory for better organization and accessibility.

- Adds a `utils.bash` file to store common utility functions

- Updates existing GH workflows to align with the refactored script and
  adds a new step to upload test artifacts for easier debugging in case
  of failures.

-  Updates the `README.md` file

Addresses #452 #469 

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
