### PR TITLE
fix(config): use predictable paths and proper typings

### DIFF
--- a/src/kepler_model/estimate/estimator.py
+++ b/src/kepler_model/estimate/estimator.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import pathlib
 import shutil
 import signal
 import socket
@@ -188,11 +189,11 @@ def sig_handler(signum, frame) -> None:
 @click.option(
     "--config-dir",
     "-c",
-    type=click.Path(exists=False, dir_okay=True, file_okay=False),
+    type=click.Path(exists=False, dir_okay=True, file_okay=False, path_type=pathlib.Path),
     default=CONFIG_PATH,
     required=False,
 )
-def run(log_level: str, machine_spec: str, config_dir: str) -> int:
+def run(log_level: str, machine_spec: str, config_dir: pathlib.Path) -> int:
     level = getattr(logging, log_level.upper())
     logging.basicConfig(
         level=level,

--- a/src/kepler_model/train/exporter/validator.py
+++ b/src/kepler_model/train/exporter/validator.py
@@ -22,7 +22,7 @@ class ExportModel:
         self.feature_group = feature_group
         self.model_name = model_name
         self.source_model_group_path = get_model_group_path(models_path, output_type, feature_group, energy_source, assure=False, pipeline_name=pipeline_name)
-        self.source_model_path = os.path.join(self.source_model_group_path, self.model_name)
+        self.source_model_path = self.source_model_group_path / self.model_name
         self.source_model_zip = get_archived_file(self.source_model_group_path, self.model_name)
         self.metadata = metadata
         self.node_type = metadata["node_type"]

--- a/src/kepler_model/train/online_trainer.py
+++ b/src/kepler_model/train/online_trainer.py
@@ -6,14 +6,12 @@ from kepler_model.train.isolator.isolator import MinIdleIsolator, ProfileBackgro
 from kepler_model.train.pipeline import NewPipeline
 from kepler_model.train.profiler.profiler import load_all_profiles
 from kepler_model.train.prom.prom_query import PrometheusClient
-from kepler_model.util.config import getConfig
+from kepler_model.util.config import get_config
 from kepler_model.util.loader import default_train_output_pipeline
 from kepler_model.util.prom_types import PROM_QUERY_INTERVAL, get_valid_feature_group_from_queries
 from kepler_model.util.train_types import FeatureGroups, PowerSourceMap
 
-SAMPLING_INTERVAL = PROM_QUERY_INTERVAL
-SAMPLING_INTERVAL = getConfig("SAMPLING_INTERVAL", SAMPLING_INTERVAL)
-SAMPLING_INTERVAL = int(SAMPLING_INTERVAL)
+SAMPLING_INTERVAL = get_config("SAMPLING_INTERVAL", PROM_QUERY_INTERVAL)
 
 
 default_trainers = ["GradientBoostingRegressorTrainer"]

--- a/src/kepler_model/train/pipeline.py
+++ b/src/kepler_model/train/pipeline.py
@@ -209,11 +209,11 @@ class Pipeline:
         print_bounded_multiline_message(messages)
 
     def archive_pipeline(self):
-        save_path = os.path.join(model_toppath, self.name)
+        save_path = model_toppath / self.name
         archived_file = get_archived_file(model_toppath, self.name)
-        self.print_log("archive pipeline :" + archived_file)
-        self.print_log("save_path :" + save_path)
-        shutil.make_archive(save_path, "zip", save_path)
+        self.print_log(f"archive pipeline : {archived_file}")
+        self.print_log(f"save_path : {save_path}")
+        shutil.make_archive(str(save_path), "zip", save_path)
 
 
 def initial_trainers(trainer_names, node_level, pipeline_name, target_energy_sources, valid_feature_groups):

--- a/src/kepler_model/train/profiler/profiler.py
+++ b/src/kepler_model/train/profiler/profiler.py
@@ -15,11 +15,13 @@
 
 import json
 import os
+import pathlib
 from urllib.request import urlopen
 
 import joblib
 import pandas as pd
 
+from kepler_model.util import config
 from kepler_model.util.extract_types import component_to_col
 from kepler_model.util.loader import default_node_type
 from kepler_model.util.prom_types import generate_dataframe_from_response, node_info_column, node_info_query
@@ -30,23 +32,13 @@ min_watt_key = "min_watt"
 max_watt_key = "max_watt"
 unit_num_key = "#unit"
 
-resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "resource")
-default_profile_top_path = os.path.join(resource_path, "profiles")
-
-if not os.path.exists(resource_path):
-    os.mkdir(resource_path)
-
+default_profile_top_path = config.RESOURCE_DIR / "profiles"
 profiler_registry = "https://raw.githubusercontent.com/sustainable-computing-io/kepler-model-db/main/profiles"
 
 
-def prepare_profile_path(profile_top_path):
-    if not os.path.exists(profile_top_path):
-        os.mkdir(profile_top_path)
-
-    profile_path = os.path.join(profile_top_path, "profile")
-    if not os.path.exists(profile_path):
-        os.mkdir(profile_path)
-
+def prepare_profile_path(profile_top_path: str | pathlib.Path) -> pathlib.Path:
+    profile_path = pathlib.Path(profile_top_path) / "profile"
+    os.makedirs(profile_path, exist_ok=True)
     return profile_path
 
 

--- a/src/kepler_model/train/trainer/__init__.py
+++ b/src/kepler_model/train/trainer/__init__.py
@@ -238,9 +238,9 @@ class Trainer(metaclass=ABCMeta):
         save_path = self._get_save_path(node_type)
         model_name, _ = self._model_filename(node_type)
         archived_file = get_archived_file(self.group_path, model_name)
-        self.print_log("archive model :" + archived_file)
-        self.print_log("save_path :" + save_path)
-        shutil.make_archive(save_path, "zip", save_path)
+        self.print_log(f"archive model :  {archived_file}")
+        self.print_log(f"save_path : {save_path}")
+        shutil.make_archive(str(save_path), "zip", save_path)
         weight_dict = self.get_weight_dict(node_type)
         if weight_dict is not None:
             save_weight(save_path, weight_dict)

--- a/src/kepler_model/util/__init__.py
+++ b/src/kepler_model/util/__init__.py
@@ -1,5 +1,5 @@
 # commonly-used definitions
-from .config import getConfig, model_toppath
+from .config import get_config, model_toppath
 from .loader import (
     class_to_json,
     default_train_output_pipeline,
@@ -47,7 +47,7 @@ __all__ = [
     "save_metadata",
     "save_scaler",
     "save_weight",
-    "getConfig",
+    "get_config",
     "model_toppath",
     "SYSTEM_FEATURES",
     "COUNTER_FEAUTRES",

--- a/src/kepler_model/util/config.py
+++ b/src/kepler_model/util/config.py
@@ -14,6 +14,8 @@
 
 import logging
 import os
+import pathlib
+import typing
 
 import requests
 
@@ -23,88 +25,128 @@ from .train_types import FeatureGroup, ModelOutputType, is_output_type_supported
 logger = logging.getLogger(__name__)
 
 
-# must be writable (for shared volume mount)
-MNT_PATH = "/mnt"
 # can be read only (for configmap mount)
-CONFIG_PATH = "/etc/kepler/kepler.config"
-
-DOWNLOAD_FOLDERNAME = "download"
-MODEL_FOLDERNAME = "models"
+CONFIG_PATH = pathlib.Path(os.environ.get("CONFIG_PATH", "/etc/kepler/kepler.config"))
 
 DEFAULT_TOTAL_SOURCE = "acpi"
 DEFAULT_COMPONENTS_SOURCE = "rapl-sysfs"
 TOTAL_KEY = "TOTAL"
 COMPONENTS_KEY = "COMPONENTS"
 
-modelConfigPrefix = ["_".join([level, coverage]) for level in ["NODE", "CONTAINER", "PROCESS"] for coverage in [TOTAL_KEY, COMPONENTS_KEY]]
 
 MODEL_SERVER_SVC = "kepler-model-server.kepler.svc.cluster.local"
 DEFAULT_MODEL_SERVER_PORT = 8100
 MODEL_SERVER_ENDPOINT = f"http://{MODEL_SERVER_SVC}:{DEFAULT_MODEL_SERVER_PORT}"
 MODEL_SERVER_MODEL_REQ_PATH = "/model"
 MODEL_SERVER_MODEL_LIST_PATH = "/best-models"
-MODEL_SERVER_ENABLE = False
 
 SERVE_SOCKET = "/tmp/estimator.sock"
 
 
-def set_config_dir(config_dir: str):
+def set_config_dir(config_dir: pathlib.Path):
     global CONFIG_PATH
     CONFIG_PATH = config_dir
 
 
-def getConfig(key: str, default):
+T_conf = typing.TypeVar("T_conf", int, float, bool, str, pathlib.Path, list[str])
+
+
+def _value_or_default(value: str | None, default: T_conf) -> T_conf:
+    if value == "" or value is None:
+        return default
+
+    if isinstance(default, bool):
+        return value == "true"
+
+    if isinstance(default, int):
+        return int(value)
+
+    if isinstance(default, float):
+        return float(value)
+
+    if isinstance(default, str):
+        return value
+
+    if isinstance(default, pathlib.Path):
+        return pathlib.Path(value)
+
+    if isinstance(default, list):
+        return [v.strip() for v in value.split(",")]
+
+
+def get_config(key: str, default: T_conf) -> T_conf:
     # check configmap path
-    file = os.path.join(CONFIG_PATH, key)
+    file = CONFIG_PATH / key
+
+    # CONFIG_FILES take precedence over env
     if os.path.exists(file):
         with open(file) as f:
-            return f.read().strip()
+            return _value_or_default(f.read().strip(), default)
+
     # check env
-    cfg = os.environ.get(key, default)
-    if type(cfg) is str:
-        return cfg.strip()
-    return cfg
+    if key in os.environ:
+        return _value_or_default(os.environ[key].strip(), default)
+
+    return default
 
 
-def getPath(subpath):
-    path = os.path.join(MNT_PATH, subpath)
-    if not os.path.exists(path):
-        os.mkdir(path)
-    return path
+def _init_mnt_path() -> pathlib.Path:
+    # update value from environment if exists
+    # must be writable (for shared volume mount)
+    mnt_path = get_config("MNT_PATH", pathlib.Path("/mnt"))
+
+    if not os.path.exists(mnt_path) or not os.access(mnt_path, os.W_OK):
+        # use local path if not exists or cannot write
+        tmp_mnt_path = pathlib.Path("/tmp/model-server/mnt")
+        logger.warning(f"cannot write to MNT_PATH - {mnt_path}, falling back to using tmp path: {tmp_mnt_path}")
+        mnt_path = tmp_mnt_path
+
+    os.makedirs(mnt_path, exist_ok=True)
+    return mnt_path
 
 
-# update value from environment if exists
-MNT_PATH = getConfig("MNT_PATH", MNT_PATH)
-if not os.path.exists(MNT_PATH) or not os.access(MNT_PATH, os.W_OK):
-    # use local path if not exists or cannot write
-    MNT_PATH = os.path.join(os.path.dirname(__file__), "..")
+MNT_PATH = _init_mnt_path()
 
-model_topurl = getConfig("MODEL_TOPURL", base_model_url)
-initial_pipeline_urls = getConfig("INITIAL_PIPELINE_URL", "")
-if initial_pipeline_urls == "":
+
+model_topurl = get_config("MODEL_TOPURL", base_model_url)
+
+
+def _init_initial_pipeline_urls(model_topurl) -> list[str]:
+    urls = get_config("INITIAL_PIPELINE_URL", [])
+    if urls:
+        return urls
+
     if model_topurl == base_model_url:
-        initial_pipeline_urls = [get_pipeline_url(model_topurl=model_topurl, pipeline_name=pipeline_name) for pipeline_name in default_pipelines.values()]
-    else:
-        initial_pipeline_urls = [get_pipeline_url(model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)]
-else:
-    initial_pipeline_urls = initial_pipeline_urls.split(",")
+        return [get_pipeline_url(model_topurl=model_topurl, pipeline_name=p) for p in default_pipelines.values()]
 
-model_toppath = getConfig("MODEL_PATH", getPath(MODEL_FOLDERNAME))
-download_path = getConfig("MODEL_PATH", getPath(DOWNLOAD_FOLDERNAME))
-
-ERROR_KEY = "mae"
-ERROR_KEY = getConfig("ERROR_KEY", ERROR_KEY)
+    return [get_pipeline_url(model_topurl=model_topurl, pipeline_name=default_train_output_pipeline)]
 
 
-def is_model_server_enabled():
-    return getConfig("MODEL_SERVER_ENABLE", "false").lower() == "true"
+initial_pipeline_urls = _init_initial_pipeline_urls(model_topurl)
+
+model_toppath = get_config("MODEL_PATH", MNT_PATH / "models")
+download_path = get_config("MODEL_PATH", MNT_PATH / "download")
+os.makedirs(download_path, exist_ok=True)
+os.makedirs(model_toppath, exist_ok=True)
+
+ERROR_KEY = get_config("ERROR_KEY", "mae")
+
+RESOURCE_DIR = get_config("RESOURCE_DIR", pathlib.Path("/tmp/model-server/resources"))
+os.makedirs(RESOURCE_DIR, exist_ok=True)
+
+
+MODEL_SERVER_ENABLE = get_config("MODEL_SERVER_ENABLE", False)
+
+
+def is_model_server_enabled() -> bool:
+    MODEL_SERVER_ENABLE = get_config("MODEL_SERVER_ENABLE", False)
+    return MODEL_SERVER_ENABLE
 
 
 def _model_server_endpoint():
-    MODEL_SERVER_URL = getConfig("MODEL_SERVER_URL", MODEL_SERVER_SVC)
+    MODEL_SERVER_URL = get_config("MODEL_SERVER_URL", MODEL_SERVER_SVC)
     if MODEL_SERVER_URL == MODEL_SERVER_SVC:
-        MODEL_SERVER_PORT = getConfig("MODEL_SERVER_PORT", DEFAULT_MODEL_SERVER_PORT)
-        MODEL_SERVER_PORT = int(MODEL_SERVER_PORT)
+        MODEL_SERVER_PORT = get_config("MODEL_SERVER_PORT", DEFAULT_MODEL_SERVER_PORT)
         modelServerEndpoint = f"http://{MODEL_SERVER_URL}:{MODEL_SERVER_PORT}"
     else:
         modelServerEndpoint = MODEL_SERVER_URL
@@ -112,16 +154,16 @@ def _model_server_endpoint():
 
 
 def get_model_server_req_endpoint():
-    return _model_server_endpoint() + getConfig("MODEL_SERVER_MODEL_REQ_PATH", MODEL_SERVER_MODEL_REQ_PATH)
+    return _model_server_endpoint() + get_config("MODEL_SERVER_MODEL_REQ_PATH", MODEL_SERVER_MODEL_REQ_PATH)
 
 
 def get_model_server_list_endpoint():
-    return _model_server_endpoint() + getConfig("MODEL_SERVER_MODEL_LIST_PATH", MODEL_SERVER_MODEL_LIST_PATH)
+    return _model_server_endpoint() + get_config("MODEL_SERVER_MODEL_LIST_PATH", MODEL_SERVER_MODEL_LIST_PATH)
 
 
 # set_env_from_model_config: extract environment values based on environment key MODEL_CONFIG
 def set_env_from_model_config():
-    model_config = getConfig("MODEL_CONFIG", "")
+    model_config = get_config("MODEL_CONFIG", "")
     if not model_config:
         return
 
@@ -138,15 +180,9 @@ def set_env_from_model_config():
             logging.info(f"set env {splits[0]} to '{splits[1]}'.")
 
 
-def is_estimator_enable(prefix):
-    envKey = "_".join([prefix, "ESTIMATOR"])
-    value = getConfig(envKey, "")
-    return value.lower() == "true"
-
-
 def get_init_url(prefix):
     envKey = "_".join([prefix, "INIT_URL"])
-    return getConfig(envKey, "")
+    return get_config(envKey, "")
 
 
 def get_energy_source(prefix):
@@ -162,7 +198,9 @@ def get_init_model_url(energy_source, output_type, model_topurl=model_topurl):
         pipeline_name = default_pipelines[energy_source]
     else:
         pipeline_name = default_train_output_pipeline
-    for prefix in modelConfigPrefix:
+
+    model_prefixes = ["_".join([level, coverage]) for level in ["NODE", "CONTAINER", "PROCESS"] for coverage in [TOTAL_KEY, COMPONENTS_KEY]]
+    for prefix in model_prefixes:
         if get_energy_source(prefix) == energy_source:
             modelURL = get_init_url(prefix)
             logger.info(f"get init url: {modelURL}")
@@ -188,7 +226,7 @@ def get_init_model_url(energy_source, output_type, model_topurl=model_topurl):
                         response = requests.get(url)
                         if response.status_code == 200:
                             modelURL = url
-                logger.info(f"init URL is not set, use {modelURL}")
+                logger.warn(f"init URL is not set, using {modelURL}")
             return modelURL
-    logger.info(f"no match config for {output_type}, {energy_source}")
+    logger.warn(f"no matching config for {output_type}, {energy_source} found")
     return ""

--- a/src/kepler_model/util/prom_types.py
+++ b/src/kepler_model/util/prom_types.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from .config import getConfig
+from .config import get_config
 from .train_types import (
     SYSTEM_FEATURES,
     WORKLOAD_FEATURES,
@@ -10,24 +10,17 @@ from .train_types import (
     get_valid_feature_groups,
 )
 
-PROM_SERVER = "http://localhost:9090"
-PROM_SSL_DISABLE = "True"
-PROM_HEADERS = ""
-PROM_QUERY_INTERVAL = 300
-PROM_QUERY_STEP = 3
-PROM_QUERY_START_TIME = ""
-PROM_QUERY_END_TIME = ""
-
-PROM_SERVER = getConfig("PROM_SERVER", PROM_SERVER)
-PROM_HEADERS = getConfig("PROM_HEADERS", PROM_HEADERS)
+PROM_SERVER = get_config("PROM_SERVER", "http://localhost:9090")
+PROM_HEADERS: None | str = get_config("PROM_HEADERS", "")
 PROM_HEADERS = None if PROM_HEADERS == "" else PROM_HEADERS
-PROM_SSL_DISABLE = True if getConfig("PROM_SSL_DISABLE", PROM_SSL_DISABLE).lower() == "true" else False
-PROM_QUERY_INTERVAL = getConfig("PROM_QUERY_INTERVAL", PROM_QUERY_INTERVAL)
-PROM_QUERY_STEP = getConfig("PROM_QUERY_STEP", PROM_QUERY_STEP)
-PROM_QUERY_START_TIME = getConfig("PROM_QUERY_START_TIME", PROM_QUERY_START_TIME)
-PROM_QUERY_END_TIME = getConfig("PROM_QUERY_END_TIME", PROM_QUERY_END_TIME)
 
-PROM_THIRDPARTY_METRICS = getConfig("PROM_THIRDPARTY_METRICS", "").split(",")
+PROM_SSL_DISABLE = get_config("PROM_SSL_DISABLE", True)
+PROM_QUERY_INTERVAL = get_config("PROM_QUERY_INTERVAL", 300)
+PROM_QUERY_STEP = get_config("PROM_QUERY_STEP", 3)
+PROM_QUERY_START_TIME = get_config("PROM_QUERY_START_TIME", "")
+PROM_QUERY_END_TIME = get_config("PROM_QUERY_END_TIME", "")
+
+PROM_THIRDPARTY_METRICS = get_config("PROM_THIRDPARTY_METRICS", list[str]([]))
 
 metric_prefix = "kepler_"
 TIMESTAMP_COL = "timestamp"

--- a/src/kepler_model/util/saver.py
+++ b/src/kepler_model/util/saver.py
@@ -29,8 +29,9 @@ def assure_path(path):
 
 
 def save_json(path, name, data):
-    if ".json" not in name:
+    if name.endswith(".json") is False:
         name = name + ".json"
+
     assure_path(path)
     filename = os.path.join(path, name)
     with open(filename, "w") as f:


### PR DESCRIPTION
This modifies config to make use of proper python typing for config and to make use of predictable paths for directories

Changes include:
* adding new RESOURCE_DIR config for resources dir
* add typing info to get_config to return proper types
* fix casing to follow pep8

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [ ] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
