### PR TITLE
fix(prom): remove unused PROM_ configs

### DIFF
--- a/manifests/server/online-train/patch-trainer.yaml
+++ b/manifests/server/online-train/patch-trainer.yaml
@@ -7,7 +7,6 @@ data:
   PROM_SERVER: http://prometheus-k8s.monitoring.svc.cluster.local:9090
   PROM_QUERY_INTERVAL: 20
   PROM_QUERY_STEP: 3
-  PROM_HEADERS: ""
   PROM_SSL_DISABLE: true
 ---
 apiVersion: apps/v1

--- a/manifests/server/openshift/online-train/patch-trainer.yaml
+++ b/manifests/server/openshift/online-train/patch-trainer.yaml
@@ -7,7 +7,6 @@ data:
   PROM_SERVER: http://prometheus-operated.openshift-monitoring.svc.cluster.local:9090
   PROM_QUERY_INTERVAL: 20
   PROM_QUERY_STEP: 3
-  PROM_HEADERS: ""
   PROM_SSL_DISABLE: true
 ---
 apiVersion: apps/v1

--- a/src/kepler_model/cmd/main.py
+++ b/src/kepler_model/cmd/main.py
@@ -27,10 +27,7 @@ from kepler_model.util.loader import (
     load_pipeline_metadata,
 )
 from kepler_model.util.prom_types import (
-    PROM_HEADERS,
-    PROM_QUERY_END_TIME,
     PROM_QUERY_INTERVAL,
-    PROM_QUERY_START_TIME,
     PROM_QUERY_STEP,
     PROM_SERVER,
     PROM_SSL_DISABLE,
@@ -85,7 +82,7 @@ query
 
 
 arguments:
-- --server : specify prometheus server URL (PROM_HEADERS and PROM_SSL_DISABLE configuration might be set via configmap or environment variables if needed)
+- --server : specify prometheus server URL (PROM_SSL_DISABLE configuration may be set via configmap or environment variables if needed)
 - --output : specify query output file name.  There will be two files generated: [output].json and [output]_validate_result.csv for kepler query response and validated results.
 - --metric-prefix : specify prefix to filter target query metrics (default: kepler)
 - --thirdparty-metrics : specify list of third party metrics to query in addition to the metrics with specified metric prefix (optional)
@@ -110,7 +107,7 @@ def query(args):
     generate_spec(data_path, machine_id)
     from prometheus_api_client import PrometheusConnect
 
-    prom = PrometheusConnect(url=args.server, headers=PROM_HEADERS, disable_ssl=PROM_SSL_DISABLE)
+    prom = PrometheusConnect(url=args.server, disable_ssl=PROM_SSL_DISABLE)
     start = None
     end = None
     if args.input:
@@ -997,8 +994,8 @@ def run():
     # Query arguments
     parser.add_argument("-s", "--server", type=str, help="Specify prometheus server.", default=PROM_SERVER)
     parser.add_argument("--interval", type=int, help="Specify query interval.", default=PROM_QUERY_INTERVAL)
-    parser.add_argument("--start-time", type=str, help="Specify query start time.", default=PROM_QUERY_START_TIME)
-    parser.add_argument("--end-time", type=str, help="Specify query end time.", default=PROM_QUERY_END_TIME)
+    parser.add_argument("--start-time", type=str, help="Specify query start time.", default="")
+    parser.add_argument("--end-time", type=str, help="Specify query end time.", default="")
     parser.add_argument("--step", type=str, help="Specify query step.", default=PROM_QUERY_STEP)
     parser.add_argument("--metric-prefix", type=str, help="Specify metrix prefix to filter.", default=KEPLER_METRIC_PREFIX)
     parser.add_argument("-tm", "--thirdparty-metrics", nargs="+", help="Specify the thirdparty metrics that are not included by Kepler", default="")

--- a/src/kepler_model/train/prom/prom_query.py
+++ b/src/kepler_model/train/prom/prom_query.py
@@ -3,7 +3,6 @@ import datetime
 from prometheus_api_client import PrometheusConnect
 
 from kepler_model.util.prom_types import (
-    PROM_HEADERS,
     PROM_QUERY_INTERVAL,
     PROM_QUERY_STEP,
     PROM_SERVER,
@@ -24,9 +23,9 @@ def _range_queries(prom, metric_list, start, end, step, params=None):
 
 class PrometheusClient:
     def __init__(self):
-        self.prom = PrometheusConnect(url=PROM_SERVER, headers=PROM_HEADERS, disable_ssl=PROM_SSL_DISABLE)
-        self.interval = int(PROM_QUERY_INTERVAL)
-        self.step = int(PROM_QUERY_STEP)
+        self.prom = PrometheusConnect(url=PROM_SERVER, disable_ssl=PROM_SSL_DISABLE)
+        self.interval = PROM_QUERY_INTERVAL
+        self.step = PROM_QUERY_STEP
         self.latest_query_result = dict()
 
     def query(self):

--- a/src/kepler_model/util/prom_types.py
+++ b/src/kepler_model/util/prom_types.py
@@ -11,14 +11,9 @@ from .train_types import (
 )
 
 PROM_SERVER = get_config("PROM_SERVER", "http://localhost:9090")
-PROM_HEADERS: None | str = get_config("PROM_HEADERS", "")
-PROM_HEADERS = None if PROM_HEADERS == "" else PROM_HEADERS
-
 PROM_SSL_DISABLE = get_config("PROM_SSL_DISABLE", True)
 PROM_QUERY_INTERVAL = get_config("PROM_QUERY_INTERVAL", 300)
 PROM_QUERY_STEP = get_config("PROM_QUERY_STEP", 3)
-PROM_QUERY_START_TIME = get_config("PROM_QUERY_START_TIME", "")
-PROM_QUERY_END_TIME = get_config("PROM_QUERY_END_TIME", "")
 
 PROM_THIRDPARTY_METRICS = get_config("PROM_THIRDPARTY_METRICS", list[str]([]))
 


### PR DESCRIPTION
This commit removes the following
* PROM_QUERY_START_TIME, PROM_QUERY_END_TIME since the config is only used in kepler_model main.py to be used as default values.

* PROM_HEADERS: since the current format is a `str` and the expected format for headers is `dict[str, str]` for header: value to be set in http requests. This is removed until get_config can handle parsing str -> dict[str, str]

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
