### PR TITLE
fix: check length of PROM_THIRDPARTY_METRICS

### DIFF
--- a/src/kepler_model/cmd/main.py
+++ b/src/kepler_model/cmd/main.py
@@ -148,7 +148,7 @@ def query(args):
     queries = None
     if args.thirdparty_metrics != "":
         queries = [m for m in available_metrics if args.metric_prefix in m or m in args.thirdparty_metrics]
-    elif [""] != PROM_THIRDPARTY_METRICS:
+    elif len(PROM_THIRDPARTY_METRICS) > 0:
         queries = [m for m in available_metrics if args.metric_prefix in m or m in PROM_THIRDPARTY_METRICS]
     else:
         queries = [m for m in available_metrics if args.metric_prefix in m]
@@ -213,7 +213,7 @@ def extract(args):
     # Inject thirdparty_metrics to FeatureGroup
     if args.thirdparty_metrics != "":
         update_thirdparty_metrics(args.thirdparty_metrics)
-    elif [""] != PROM_THIRDPARTY_METRICS:
+    elif len(PROM_THIRDPARTY_METRICS) > 0:
         update_thirdparty_metrics(PROM_THIRDPARTY_METRICS)
     valid_fg = get_valid_feature_group_from_queries([query for query in query_results.keys() if len(query_results[query]) > 1])
     ot, fg = check_ot_fg(args, valid_fg)
@@ -331,7 +331,7 @@ def train_from_data(args):
     # Inject thirdparty_metrics to FeatureGroup
     if args.thirdparty_metrics != "":
         update_thirdparty_metrics(args.thirdparty_metrics)
-    elif [""] != PROM_THIRDPARTY_METRICS:
+    elif len(PROM_THIRDPARTY_METRICS) > 0:
         update_thirdparty_metrics(PROM_THIRDPARTY_METRICS)
     valid_fg = [fg_key for fg_key in FeatureGroups.keys()]
     ot, fg = check_ot_fg(args, valid_fg)
@@ -423,7 +423,7 @@ def train(args):
     # Inject thirdparty_metrics to FeatureGroup
     if args.thirdparty_metrics != "":
         update_thirdparty_metrics(args.thirdparty_metrics)
-    elif [""] != PROM_THIRDPARTY_METRICS:
+    elif len(PROM_THIRDPARTY_METRICS) > 0:
         update_thirdparty_metrics(PROM_THIRDPARTY_METRICS)
 
     pipeline_name = default_train_output_pipeline
@@ -563,7 +563,7 @@ def estimate(args):
     # Inject thirdparty_metrics to FeatureGroup
     if args.thirdparty_metrics != "":
         update_thirdparty_metrics(args.thirdparty_metrics)
-    elif [""] != PROM_THIRDPARTY_METRICS:
+    elif len(PROM_THIRDPARTY_METRICS) > 0:
         update_thirdparty_metrics(PROM_THIRDPARTY_METRICS)
 
     inputs = args.input.split(",")


### PR DESCRIPTION
This commit updates the condition to check the length of `PROM_THIRDPARTY_METRICS` instead of comparing it to `[""]`

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
