### PR TITLE
chore(Dockerfile): remove platform flag from FROM instruction

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_model_server_base:latest
+FROM quay.io/sustainable_computing_io/kepler_model_server_base:latest
 
 WORKDIR /kepler_model
 ENV PYTHONPATH=/kepler_model

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 quay.io/sustainable_computing_io/kepler_model_server_base:latest
+FROM quay.io/sustainable_computing_io/kepler_model_server_base:latest
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
This commit removes the `--platform` flag from `FROM` lines in the Dockerfiles as Docker discourages the use of hardcoded platform in the `FROM` instruction

Addresses #514 

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
