### PR TITLE
chore(docs): update commands to use package name

### DIFF
--- a/model_training/cmd_instruction.md
+++ b/model_training/cmd_instruction.md
@@ -1,5 +1,19 @@
 # Manual Metric Collection and Training with Entrypoint
 
+<!--toc:start-->
+
+- [Manual Metric Collection and Training with Entrypoint](#manual-metric-collection-and-training-with-entrypoint)
+  - [1. Collect metrics](#1-collect-metrics)
+    - [1.1. By defining start time and end time](#11-by-defining-start-time-and-end-time)
+    - [1.2. By defining last interval from the execution time](#12-by-defining-last-interval-from-the-execution-time)
+    - [Output](#output)
+  - [2. Train models](#2-train-models)
+  - [3. Export models](#3-export-models)
+    - [3.1. Extracting collect date from benchmark file](#31-extracting-collect-date-from-benchmark-file)
+    - [3.2. Manually set collect-date](#32-manually-set-collect-date)
+
+<!--toc:end-->
+
 ## 1. Collect metrics
 
 Without benchmark/pipeline automation, kepler metrics can be collected by `query` function by setting `BENCHMARK`, `PROM_URL`, `COLLECT_ID` and either one of the following time options.
@@ -12,7 +26,7 @@ PROM_URL= # e.g., http://localhost:9090
 COLLECT_ID= # any unique id e.g., machine name
 ```
 
-### 1.1. by defining start time and end time
+### 1.1. By defining start time and end time
 
 ```bash
 # time value setting
@@ -20,17 +34,17 @@ START_TIME= # format date +%Y-%m-%dT%H:%M:%SZ
 END_TIME= # format date +%Y-%m-%dT%H:%M:%SZ
 
 # query execution
-DATAPATH=/path/to/workspace python cmd/main.py query --benchmark $BENCHMARK --server $PROM_URL --output kepler_query --start-time $START_TIME --end-time $END_TIME --id $COLLECT_ID
+DATAPATH=/path/to/workspace kepler-model query --benchmark $BENCHMARK --server $PROM_URL --output kepler_query --start-time $START_TIME --end-time $END_TIME --id $COLLECT_ID
 ```
 
-### 1.2. by defining last interval from the execution time
+### 1.2. By defining last interval from the execution time
 
 ```bash
 # time value setting
 INTERVAL= # in second
 
 # query execution
-DATAPATH=/path/to/workspace python cmd/main.py query --benchmark $BENCHMARK --server $PROM_URL --output kepler_query --interval $INTERVAL --id $COLLECT_ID
+DATAPATH=/path/to/workspace kepler-model query --benchmark $BENCHMARK --server $PROM_URL --output kepler_query --interval $INTERVAL --id $COLLECT_ID
 ```
 
 ### Output
@@ -49,7 +63,7 @@ PIPELINE_NAME= # any unique name for the pipeline (one pipeline can be accumulat
 
 # train execution
 # require COLLECT_ID from collect step
-DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace python cmd/main.py train --pipeline-name $PIPELINE_NAME --input kepler_query --id $COLLECT_ID
+DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace kepler-model train --pipeline-name $PIPELINE_NAME --input kepler_query --id $COLLECT_ID
 ```
 
 ## 3. Export models
@@ -61,7 +75,7 @@ EXPORT_PATH= # /path/to/kepler-model-db/models
 PUBLISHER= # github account of publisher
 ```
 
-### 3.1. extracting collect date from benchmark file
+### 3.1. Extracting collect date from benchmark file
 
 The benchmark file is created by CPE operator or by query function from step 1.
 
@@ -69,10 +83,10 @@ The benchmark file is created by CPE operator or by query function from step 1.
 # export execution
 # require BENCHMARK from collect step
 # require PIPELINE_NAME from train step
-DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace python cmd/main.py export --benchmark $BENCHMARK --pipeline-name $PIPELINE_NAME -o $EXPORT_PATH --publisher $PUBLISHER --zip=true 
+DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace kepler-model export --benchmark $BENCHMARK --pipeline-name $PIPELINE_NAME -o $EXPORT_PATH --publisher $PUBLISHER --zip=true 
 ```
 
-### 3.2. manually set collect-date
+### 3.2. Manually set collect-date
 
 If the data is collected by tekton, there is no benchmark file created. Need to manually set `--collect-date` instead of `--benchmark` parameter.
 
@@ -83,5 +97,5 @@ COLLECT_DATE= # collect date
 # export execution
 # require BENCHMARK from collect step
 # require PIPELINE_NAME from train step
-DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace python cmd/main.py export --pipeline-name $PIPELINE_NAME -o $EXPORT_PATH --publisher $PUBLISHER --zip=true --collect-date $COLLECT_DATE
+DATAPATH=/path/to/workspace MODEL_PATH=/path/to/workspace kepler-model export --pipeline-name $PIPELINE_NAME -o $EXPORT_PATH --publisher $PUBLISHER --zip=true --collect-date $COLLECT_DATE
 ```


### PR DESCRIPTION
This commit updates the commands to use the `kepler-model` package name instead of `python ...` to run the model training commands.

Addresses: #530

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
