### PR TITLE
chore(ci): add wait for tekton deployment to finish

### DIFF
--- a/.github/workflows/collect-data-self-hosted.yml
+++ b/.github/workflows/collect-data-self-hosted.yml
@@ -117,6 +117,15 @@ jobs:
             regionName: ${{ secrets.aws_region }}
             bucketName: kepler-power-model
           EOF
+
+      # TODO: Remove this once the fix is released in new kepler-action version
+      - name: Wait for Tekton to be ready
+        run: |
+          kubectl wait deployment tekton-pipelines-controller \
+            --for=condition=Available --namespace tekton-pipelines --timeout=5m
+          kubectl wait deployment tekton-pipelines-webhook \
+            --for=condition=Available --namespace tekton-pipelines --timeout=5m
+
       - name: Deploy Tasks and Pipelines
         working-directory: model_training/tekton
         run: |

--- a/.github/workflows/tekton-test.yml
+++ b/.github/workflows/tekton-test.yml
@@ -86,6 +86,14 @@ jobs:
           export KUBECONFIG_ROOT_DIR=/tmp/kubeconfig
           kubectl apply -f pvc/hostpath.yaml
 
+      # TODO: Remove this once the fix is released in new kepler-action version
+      - name: Wait for Tekton to be ready
+        run: |
+          kubectl wait deployment tekton-pipelines-controller \
+            --for=condition=Available --namespace tekton-pipelines --timeout=5m
+          kubectl wait deployment tekton-pipelines-webhook \
+            --for=condition=Available --namespace tekton-pipelines --timeout=5m
+
       - name: Deploy Tasks and Pipelines
         working-directory: model_training/tekton
         run: |

--- a/.github/workflows/train-model.yml
+++ b/.github/workflows/train-model.yml
@@ -144,6 +144,14 @@ jobs:
             bucketName: kepler-power-model
           EOF
 
+      # TODO: Remove this once the fix is released in new kepler-action version
+      - name: Wait for Tekton to be ready
+        run: |
+          kubectl wait deployment tekton-pipelines-controller \
+            --for=condition=Available --namespace tekton-pipelines --timeout=5m
+          kubectl wait deployment tekton-pipelines-webhook \
+            --for=condition=Available --namespace tekton-pipelines --timeout=5m
+
       - name: Deploy Tasks and Pipelines
         working-directory: model_training/tekton
         run: |


### PR DESCRIPTION
This commit adds a wait for tekton deployment to finish on CI before deploying tasks and pipelines
Also, it is a temporary fix until the issue is addressed in next release of kepler-action

Failure CI: https://github.com/sustainable-computing-io/kepler-model-server/actions/runs/11572919947/job/32214031737

# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [ ] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [x] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.
