### PR TITLE
fix: unmatch namespace in online trainer patch

### DIFF
--- a/manifests/server/online-train/patch-trainer.yaml
+++ b/manifests/server/online-train/patch-trainer.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kepler-model-server-cfm
-  namespace: kepler
+  namespace: system
 data:
   PROM_SERVER: http://prometheus-k8s.monitoring.svc.cluster.local:9090
   PROM_QUERY_INTERVAL: 20
@@ -13,7 +13,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kepler-model-server
-  namespace: kepler
+  namespace: system
 spec:
   template:
     spec:


### PR DESCRIPTION
Fix
 
```
> OPTS="ESTIMATOR SERVER ONLINE_TRAINER" make manifest
```
> Error: accumulating resources: accumulation err='accumulating resources from '../server': '/home/ninine/kepler-model-server/manifests/server' must resolve to a file': recursed accumulation of path '/home/ninine/kepler-model-server/manifests/server': no matches for Id ConfigMap.v1.[noGrp]/kepler-model-server-cfm.kepler; failed to find unique target for patch ConfigMap.v1.[noGrp]/kepler-model-server-cfm.kepler


# Checklist for PR Author

---

In addition to approval, the author must confirm the following check list:

- [x] Run the following command to format your code:

  ```bash
  make fmt
  ```

- [ ] Create issues for unresolved comments and link them to this PR. Use one of the following labels:
  - `must-fix`: The logic appears incorrect and must be addressed.
  - `minor`: Typos, minor issues, or potential refactoring for better readability.
  - `nit`: Trivial issues like extra spaces, commas, etc.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>